### PR TITLE
User 엔티티 재작성

### DIFF
--- a/src/api/src/main/kotlin/grantly/user/adapter/out/UserJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/UserJpaEntity.kt
@@ -23,8 +23,6 @@ class UserJpaEntity(
     val password: String? = null,
     @Column(length = 255, nullable = false)
     var name: String,
-    @Column(length = 255, nullable = true)
-    var profileImgUrl: String? = null,
     @Column(nullable = true)
     var lastLoginAt: OffsetDateTime? = null,
 ) : BaseEntity() {

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/UserJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/UserJpaEntity.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import java.time.OffsetDateTime
 
 @Entity
 @Table(name = "user")
@@ -18,10 +19,14 @@ class UserJpaEntity(
     val id: Long? = null,
     @Column(unique = true, length = 100, nullable = false)
     val email: String,
-    @Column(length = 255, nullable = false)
-    val password: String,
+    @Column(length = 255, nullable = true)
+    val password: String? = null,
     @Column(length = 255, nullable = false)
     var name: String,
+    @Column(length = 255, nullable = true)
+    var profileImgUrl: String? = null,
+    @Column(nullable = true)
+    var lastLoginAt: OffsetDateTime? = null,
 ) : BaseEntity() {
     override fun toString() = entityToString(*toStringProperties)
 
@@ -32,6 +37,7 @@ class UserJpaEntity(
     companion object {
         // 사용할 프로퍼티 정의
         val toStringProperties = arrayOf(UserJpaEntity::id, UserJpaEntity::email)
-        val equalsAndHashCodeProperties = arrayOf(UserJpaEntity::id, UserJpaEntity::email, UserJpaEntity::name)
+        val equalsAndHashCodeProperties =
+            arrayOf(UserJpaEntity::id, UserJpaEntity::email, UserJpaEntity::name)
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/UserMapper.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/UserMapper.kt
@@ -12,7 +12,6 @@ class UserMapper : IsMapper<UserJpaEntity, User> {
             email = entity.email,
             name = entity.name,
             password = entity.password,
-            profileImgUrl = entity.profileImgUrl,
             lastLoginAt = entity.lastLoginAt,
             createdAt = entity.createdAt,
             modifiedAt = entity.modifiedAt,
@@ -24,7 +23,6 @@ class UserMapper : IsMapper<UserJpaEntity, User> {
             email = domain.email,
             name = domain.name,
             password = domain.password,
-            profileImgUrl = domain.profileImgUrl,
             lastLoginAt = domain.lastLoginAt,
         )
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/UserMapper.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/UserMapper.kt
@@ -12,10 +12,19 @@ class UserMapper : IsMapper<UserJpaEntity, User> {
             email = entity.email,
             name = entity.name,
             password = entity.password,
+            profileImgUrl = entity.profileImgUrl,
+            lastLoginAt = entity.lastLoginAt,
             createdAt = entity.createdAt,
             modifiedAt = entity.modifiedAt,
         )
 
     override fun toEntity(domain: User): UserJpaEntity =
-        UserJpaEntity(id = if (domain.id == 0L) null else domain.id, email = domain.email, name = domain.name, password = domain.password)
+        UserJpaEntity(
+            id = if (domain.id == 0L) null else domain.id,
+            email = domain.email,
+            name = domain.name,
+            password = domain.password,
+            profileImgUrl = domain.profileImgUrl,
+            lastLoginAt = domain.lastLoginAt,
+        )
 }

--- a/src/api/src/main/kotlin/grantly/user/domain/User.kt
+++ b/src/api/src/main/kotlin/grantly/user/domain/User.kt
@@ -1,6 +1,5 @@
 package grantly.user.domain
 
-import grantly.user.adapter.out.AuthType
 import java.time.OffsetDateTime
 
 data class User(
@@ -8,8 +7,6 @@ data class User(
     val email: String,
     var password: String? = null,
     var name: String,
-    val authType: AuthType = AuthType.EMAIL,
-    var profileImgUrl: String? = null,
     var lastLoginAt: OffsetDateTime? = null,
     var createdAt: OffsetDateTime = OffsetDateTime.now(),
     var modifiedAt: OffsetDateTime? = null,

--- a/src/api/src/main/kotlin/grantly/user/domain/User.kt
+++ b/src/api/src/main/kotlin/grantly/user/domain/User.kt
@@ -1,12 +1,16 @@
 package grantly.user.domain
 
+import grantly.user.adapter.out.AuthType
 import java.time.OffsetDateTime
 
 data class User(
     val id: Long = 0L,
     val email: String,
-    var password: String,
+    var password: String? = null,
     var name: String,
+    val authType: AuthType = AuthType.EMAIL,
+    var profileImgUrl: String? = null,
+    var lastLoginAt: OffsetDateTime? = null,
     var createdAt: OffsetDateTime = OffsetDateTime.now(),
     var modifiedAt: OffsetDateTime? = null,
 ) {

--- a/src/api/src/main/resources/application.yml
+++ b/src/api/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
         format_sql: true
         use_sql_comments: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     database-platform: org.hibernate.dialect.MySQL8Dialect
 management:
   endpoints:

--- a/src/api/src/main/resources/migrations/V1__add_user_table.sql
+++ b/src/api/src/main/resources/migrations/V1__add_user_table.sql
@@ -2,14 +2,13 @@ DROP TABLE IF EXISTS user;
 
 CREATE TABLE user
 (
-    id              BIGINT AUTO_INCREMENT NOT NULL,
-    created_at      datetime              NOT NULL,
-    modified_at     datetime              NOT NULL,
-    email           VARCHAR(100)          NOT NULL,
-    password        VARCHAR(255)          NULL,
-    name            VARCHAR(255)          NOT NULL,
-    profile_img_url VARCHAR(255)          NULL,
-    last_login_at   datetime              NULL,
+    id            BIGINT AUTO_INCREMENT NOT NULL,
+    created_at    datetime              NOT NULL,
+    modified_at   datetime              NOT NULL,
+    email         VARCHAR(100)          NOT NULL,
+    password      VARCHAR(255)          NULL,
+    name          VARCHAR(255)          NOT NULL,
+    last_login_at datetime              NULL,
     CONSTRAINT pk_user PRIMARY KEY (id)
 );
 

--- a/src/api/src/main/resources/migrations/V1__add_user_table.sql
+++ b/src/api/src/main/resources/migrations/V1__add_user_table.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS user;
+
+CREATE TABLE user
+(
+    id              BIGINT AUTO_INCREMENT NOT NULL,
+    created_at      datetime              NOT NULL,
+    modified_at     datetime              NOT NULL,
+    email           VARCHAR(100)          NOT NULL,
+    password        VARCHAR(255)          NULL,
+    name            VARCHAR(255)          NOT NULL,
+    profile_img_url VARCHAR(255)          NULL,
+    last_login_at   datetime              NULL,
+    CONSTRAINT pk_user PRIMARY KEY (id)
+);
+
+ALTER TABLE user
+    ADD CONSTRAINT uc_user_email UNIQUE (email);


### PR DESCRIPTION
## 변경내역
- UserJpaEntity 를 재작성하였습니다. 실제 로직은 [회원가입 API](#5) 에서 처리하겠습니다.

## 확인이 필요한 부분
- 

## 배포 전 해야 할 일

- [ ] user table 에 대한 migration 이 요구됩니다.

### DB schema change

- [ ] 유저 테이블 생성 `V1__add_user_table.sql`

## 배포 후 해야 할 일

- [ ]

### DB schema change

- [ ]

___
resolve #11