### PR TITLE
spring 프로파일 환경에 따라 분리

### DIFF
--- a/src/api/Makefile
+++ b/src/api/Makefile
@@ -4,10 +4,10 @@ build:
 	@./gradlew clean build
 
 start:
-	@java -jar build/libs/api-1.0.0.jar
+	@java -jar -Dspring.profiles.active=prod build/libs/api-1.0.0.jar
 
 dev:
-	@./gradlew bootRun
+	@SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
 
 lint:
 	ktlint --format

--- a/src/api/src/main/resources/application.yml
+++ b/src/api/src/main/resources/application.yml
@@ -13,8 +13,6 @@ spring:
         highlight_sql: true
         format_sql: true
         use_sql_comments: true
-    hibernate:
-      ddl-auto: validate
     database-platform: org.hibernate.dialect.MySQL8Dialect
 management:
   endpoints:
@@ -35,3 +33,21 @@ springdoc:
   show-actuator: true
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  jpa:
+    hibernate:
+      ddl-auto: validate


### PR DESCRIPTION
## 변경내역
- sprint profile 을 local, prod 로 분리
- local 에서는 `ddl-auto: update` prod 에서는 `ddl-auto: validate` 하도록 함

## 확인이 필요한 부분
-

## 배포 전 해야 할 일

- [ ]

### DB schema change

- [ ]

## 배포 후 해야 할 일

- [ ]

### DB schema change

- [ ]
