### PR TITLE
세션 토큰 테이블 및 로그인 API

### DIFF
--- a/src/api/src/main/kotlin/grantly/common/constants/AuthConstants.kt
+++ b/src/api/src/main/kotlin/grantly/common/constants/AuthConstants.kt
@@ -1,0 +1,8 @@
+package grantly.common.constants
+
+object AuthConstants {
+    const val SESSION_COOKIE_NAME = "session_token"
+    const val CSRF_COOKIE_NAME = "csrf_token"
+    const val CSRF_HEADER_NAME = "X-CSRF-Token"
+    const val TOKEN_EXPIRATION = 60 * 60 * 24L
+}

--- a/src/api/src/main/kotlin/grantly/common/constants/AuthConstants.kt
+++ b/src/api/src/main/kotlin/grantly/common/constants/AuthConstants.kt
@@ -2,7 +2,7 @@ package grantly.common.constants
 
 object AuthConstants {
     const val SESSION_COOKIE_NAME = "session_token"
-    const val CSRF_COOKIE_NAME = "csrf_token"
+    const val CSRF_COOKIE_NAME = "CSRF-TOKEN"
     const val CSRF_HEADER_NAME = "X-CSRF-Token"
     const val TOKEN_EXPIRATION = 60 * 60 * 24L
 }

--- a/src/api/src/main/kotlin/grantly/common/entity/EntityUtils.kt
+++ b/src/api/src/main/kotlin/grantly/common/entity/EntityUtils.kt
@@ -13,9 +13,10 @@ fun <T : Any> T.entityToString(vararg properties: KProperty1<T, *>): String {
 fun <T : Any> T.entityEquals(
     other: Any?,
     idProperty: KProperty1<T, *>,
-    vararg properties: KProperty1<T, *>,
 ): Boolean {
+    // 같은 객체인지 확인
     if (this === other) return true
+    // 타입이 다르면 비교할 수 없음
     if (other == null || this::class != other::class) return false
 
     @Suppress("UNCHECKED_CAST")
@@ -23,15 +24,15 @@ fun <T : Any> T.entityEquals(
     val thisId = idProperty.get(this)
     val otherId = idProperty.get(otherObj)
 
-    return if (thisId != null && otherId != null) {
-        thisId == otherId // ID가 있으면 ID만 비교
-    } else {
-        properties.all { it.get(this) == it.get(otherObj) } // ID가 없으면 모든 필드 비교
-    }
+    // 둘 다 아직 영속화 안 되었으면 같다고 할 수 없음
+    if (thisId == null || otherId == null) return false
+
+    return thisId == other
 }
 
 // hashCode() 자동 생성 함수
-fun <T : Any> T.entityHashCode(vararg properties: KProperty1<T, *>): Int {
-    // 0 에서 시작하는 누적값(acc)과 소수 31을 곱한 값에 각 프로퍼티의 해시코드를 더하는 과정을 반복한 값을 반환
-    return properties.fold(0) { acc, prop -> 31 * acc + (prop.get(this)?.hashCode() ?: 0) }
+fun <T : Any> T.entityHashCode(idProperty: KProperty1<T, *>): Int {
+    val id = idProperty.get(this)
+    // 아직 영속화 안 되었으면 해시코드 0
+    return id?.hashCode() ?: 0
 }

--- a/src/api/src/main/kotlin/grantly/common/exceptions/GlobalExceptionHandler.kt
+++ b/src/api/src/main/kotlin/grantly/common/exceptions/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package grantly.common.exceptions
 
 import jakarta.validation.ConstraintViolationException
+import mu.KotlinLogging
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
@@ -11,6 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import java.lang.Exception
+
+private val log = KotlinLogging.logger {}
 
 @RestControllerAdvice
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
@@ -105,7 +108,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
                 500,
                 httpError.message,
             )
-        // TODO: 실제로 발생한 Runtime exception 에 대한 로깅을 추가해야함
+        log.error { exception.message }
         return ResponseEntity(exceptionResponse, httpError.httpStatus)
     }
 }

--- a/src/api/src/main/kotlin/grantly/common/exceptions/GlobalExceptionHandler.kt
+++ b/src/api/src/main/kotlin/grantly/common/exceptions/GlobalExceptionHandler.kt
@@ -88,7 +88,6 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         statusCode: HttpStatusCode,
         request: WebRequest,
     ): ResponseEntity<Any>? {
-        println(ex.message)
         val exceptionResponse =
             HttpExceptionResponse(
                 statusCode.value(),

--- a/src/api/src/main/kotlin/grantly/common/exceptions/HttpConflictException.kt
+++ b/src/api/src/main/kotlin/grantly/common/exceptions/HttpConflictException.kt
@@ -6,6 +6,6 @@ import org.springframework.web.bind.annotation.ResponseStatus
 @ResponseStatus(HttpStatus.CONFLICT)
 class HttpConflictException : HttpException {
     constructor() : super(HttpErrorType.CONFLICT)
-    constructor(message: String) : super(HttpErrorType.CONFLICT, message)
+    constructor(message: String?) : super(HttpErrorType.CONFLICT, message)
     constructor(message: String, detail: Map<String, Any>) : super(HttpErrorType.CONFLICT, message, detail)
 }

--- a/src/api/src/main/kotlin/grantly/common/exceptions/HttpInternalServerErrorException.kt
+++ b/src/api/src/main/kotlin/grantly/common/exceptions/HttpInternalServerErrorException.kt
@@ -1,0 +1,11 @@
+package grantly.common.exceptions
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+class HttpInternalServerErrorException : HttpException {
+    constructor() : super(HttpErrorType.INTERNAL_SERVER_ERROR)
+    constructor(message: String?) : super(HttpErrorType.INTERNAL_SERVER_ERROR, message)
+    constructor(message: String, detail: Map<String, Any>) : super(HttpErrorType.INTERNAL_SERVER_ERROR, message, detail)
+}

--- a/src/api/src/main/kotlin/grantly/common/exceptions/HttpUnauthorizedException.kt
+++ b/src/api/src/main/kotlin/grantly/common/exceptions/HttpUnauthorizedException.kt
@@ -1,0 +1,11 @@
+package grantly.common.exceptions
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+class HttpUnauthorizedException : HttpException {
+    constructor() : super(HttpErrorType.AUTHENTICATION_FAILED)
+    constructor(message: String?) : super(HttpErrorType.AUTHENTICATION_FAILED, message)
+    constructor(message: String, detail: Map<String, Any>) : super(HttpErrorType.AUTHENTICATION_FAILED, message, detail)
+}

--- a/src/api/src/main/kotlin/grantly/config/CustomAuthFilter.kt
+++ b/src/api/src/main/kotlin/grantly/config/CustomAuthFilter.kt
@@ -1,0 +1,95 @@
+package grantly.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import grantly.common.constants.AuthConstants
+import grantly.common.exceptions.HttpErrorType
+import grantly.user.application.port.out.AuthSessionRepository
+import grantly.user.domain.AuthSession
+import jakarta.persistence.EntityNotFoundException
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+
+private val SAFE_HTTP_METHODS = setOf("GET", "HEAD", "OPTIONS")
+private val SKIP_PATTERNS =
+    listOf(
+        Regex(".*/login.*"),
+        Regex(".*/signup.*"),
+        Regex(".*/docs.*"),
+        Regex(".*/health.*"),
+    )
+
+class CustomAuthFilter(
+    private val authSessionRepository: AuthSessionRepository,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        // 스킵 패턴 체크
+        if (SKIP_PATTERNS.any { it.matches(request.requestURI) }) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val sessionToken = request.cookies?.find { it.name == AuthConstants.SESSION_COOKIE_NAME }?.value
+        if (sessionToken.isNullOrBlank()) {
+            response.writeErrorJson(HttpErrorType.AUTHENTICATION_FAILED, "Session token not found")
+            return
+        }
+        // 세션 토큰 검증
+        var session: AuthSession
+        try {
+            session = authSessionRepository.getSessionByToken(sessionToken)
+            if (!session.isValid()) {
+                throw EntityNotFoundException()
+            }
+        } catch (e: EntityNotFoundException) {
+            response.writeErrorJson(HttpErrorType.AUTHENTICATION_FAILED, "Invalid session")
+            return
+        }
+
+        if (!isSafeMethod(request)) {
+            // CSRF 토큰 검증
+            val csrfToken = request.getHeader(AuthConstants.CSRF_HEADER_NAME)
+            if (csrfToken.isNullOrBlank()) {
+                response.writeErrorJson(HttpErrorType.AUTHENTICATION_FAILED, "CSRF token not found")
+                return
+            }
+            if (!csrfToken.equals(session.csrfToken)) {
+                response.writeErrorJson(HttpErrorType.AUTHENTICATION_FAILED, "CSRF token mismatch")
+                return
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun isSafeMethod(request: HttpServletRequest): Boolean = SAFE_HTTP_METHODS.contains(request.method)
+}
+
+/**
+ * writeErrorJson
+ *
+ * GlobalExceptionHandler 에서 반환하는 표준화된 에러 응답인 HttpExceptionResponse 와 그 형태를 맞추기 위한 메서드
+ */
+fun HttpServletResponse.writeErrorJson(
+    errorType: HttpErrorType,
+    message: String,
+    detail: Map<String, Any>? = null,
+) {
+    this.status = errorType.httpStatus.value()
+    this.contentType = "application/json"
+    this.characterEncoding = "UTF-8"
+
+    val errorResponse =
+        mapOf(
+            "code" to this.status,
+            "message" to message,
+            "detail" to detail,
+        )
+
+    val mapper = ObjectMapper().findAndRegisterModules()
+    this.writer.write(mapper.writeValueAsString(errorResponse))
+}

--- a/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
+++ b/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package grantly.config
 
+import grantly.user.application.port.out.AuthSessionRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -7,23 +8,26 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import java.security.SecureRandom
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val authSessionRepository: AuthSessionRepository,
+) {
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder(12, SecureRandom())
 
     @Bean
     fun securityFilterChainDSL(http: HttpSecurity): SecurityFilterChain {
         http
-            .csrf { it.disable() }
+            .csrf { it.disable() } // 기본 csrf 설정 비활성화
             .authorizeHttpRequests { auth ->
                 auth
                     .anyRequest()
                     .permitAll()
-            }
+            }.addFilterBefore(CustomAuthFilter(authSessionRepository), UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
     }

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
@@ -2,20 +2,29 @@ package grantly.user.adapter.`in`
 
 import grantly.common.exceptions.HttpConflictException
 import grantly.common.exceptions.HttpExceptionResponse
+import grantly.common.exceptions.HttpUnauthorizedException
 import grantly.common.utils.HttpUtil
 import grantly.common.utils.TimeUtil
+import grantly.user.adapter.`in`.dto.LoginRequest
 import grantly.user.adapter.`in`.dto.SignUpRequest
+import grantly.user.adapter.out.dto.LoginResponse
 import grantly.user.adapter.out.dto.SignUpResponse
 import grantly.user.adapter.out.dto.UserResponse
+import grantly.user.application.port.`in`.LoginUseCase
 import grantly.user.application.port.`in`.SignUpUseCase
+import grantly.user.application.port.`in`.dto.LoginParams
 import grantly.user.application.port.`in`.dto.SignUpParams
 import grantly.user.application.service.exceptions.DuplicateEmailException
+import grantly.user.application.service.exceptions.PasswordMismatchException
+import grantly.user.domain.AuthSession
 import grantly.user.domain.User
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -30,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "인증", description = "인증 관련 API")
 class AuthController(
     private val signUpUseCase: SignUpUseCase,
+    private val loginUseCase: LoginUseCase,
 ) {
     @Operation(
         summary = "이메일을 이용한 회원가입",
@@ -69,6 +79,7 @@ class AuthController(
         } catch (e: DuplicateEmailException) {
             throw HttpConflictException(e.message ?: "Email already exists")
         }
+        // TODO: 토큰 발급 및 응답에 포함
         return ResponseEntity.created(HttpUtil.buildLocationURI("/v1/users/me")).body(
             SignUpResponse(
                 user =
@@ -81,5 +92,24 @@ class AuthController(
                     ),
             ),
         )
+    }
+
+    @PostMapping("/token")
+    fun login(
+        @Valid @RequestBody body: LoginRequest,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): ResponseEntity<LoginResponse> {
+        // ip 와 user agent 를 가져옴
+        val ip = request.remoteAddr
+        val userAgent = request.getHeader("User-Agent")
+
+        val session: AuthSession
+        try {
+            session = loginUseCase.login(LoginParams(body.email, body.password, ip, userAgent), response)
+        } catch (e: PasswordMismatchException) {
+            throw HttpUnauthorizedException(e.message)
+        }
+        return ResponseEntity.ok(session.token?.let { LoginResponse(token = it) })
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
@@ -101,7 +101,7 @@ class AuthController(
             ApiResponse(responseCode = "204", description = "로그인 성공. session_token 키로 쿠키 설정"),
             ApiResponse(
                 responseCode = "401",
-                description = "비밀번호 불일치",
+                description = "비밀번호 불일치, 존재하지 않는 유저",
                 content =
                     arrayOf(
                         Content(

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.persistence.EntityNotFoundException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
@@ -123,6 +124,8 @@ class AuthController(
         val session: AuthSession
         try {
             session = loginUseCase.login(LoginParams(body.email, body.password, ip, userAgent), response)
+        } catch (e: EntityNotFoundException) {
+            throw HttpUnauthorizedException(e.message)
         } catch (e: PasswordMismatchException) {
             throw HttpUnauthorizedException(e.message)
         }

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
@@ -94,6 +94,23 @@ class AuthController(
         )
     }
 
+    @Operation(
+        summary = "이메일을 이용한 로그인",
+        responses = [
+            ApiResponse(responseCode = "200", description = "로그인 성공. session_token 키로 쿠키 설정"),
+            ApiResponse(
+                responseCode = "401",
+                description = "비밀번호 불일치",
+                content =
+                    arrayOf(
+                        Content(
+                            mediaType = "application/json",
+                            schema = Schema(implementation = HttpExceptionResponse::class),
+                        ),
+                    ),
+            ),
+        ],
+    )
     @PostMapping("/token")
     fun login(
         @Valid @RequestBody body: LoginRequest,

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
@@ -100,7 +100,6 @@ class AuthController(
         request: HttpServletRequest,
         response: HttpServletResponse,
     ): ResponseEntity<LoginResponse> {
-        // ip 와 user agent 를 가져옴
         val ip = request.remoteAddr
         val userAgent = request.getHeader("User-Agent")
 
@@ -110,6 +109,7 @@ class AuthController(
         } catch (e: PasswordMismatchException) {
             throw HttpUnauthorizedException(e.message)
         }
+        loginUseCase.setSessionCookie(response, session)
         return ResponseEntity.ok(session.token?.let { LoginResponse(token = it) })
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/dto/LoginRequest.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/dto/LoginRequest.kt
@@ -1,0 +1,15 @@
+package grantly.user.adapter.`in`.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "로그인 요청 DTO")
+data class LoginRequest(
+    @field:Email(message = "Invalid email format")
+    val email: String,
+    @field:NotBlank(message = "Password must not be blank")
+    @field:Size(min = 8, max = 100, message = "Password must be at least 8 characters long")
+    val password: String,
+)

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionJpaEntity.kt
@@ -13,22 +13,20 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
-import jakarta.persistence.UniqueConstraint
 import java.time.OffsetDateTime
 
 @Entity
 @Table(
     name = "auth_session",
-    uniqueConstraints = [
-        UniqueConstraint(name = "uq_user_id_token", columnNames = ["user_id", "token"]),
-    ],
 )
 class AuthSessionJpaEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false, unique = true, length = 50)
     val token: String,
-    @Column(nullable = true, length = 100)
+    @Column(nullable = false, length = 50)
+    val csrfToken: String,
+    @Column(nullable = true, length = 255)
     val userAgent: String? = null,
     @Column(nullable = true, length = 45)
     val ip: String? = null,
@@ -42,20 +40,12 @@ class AuthSessionJpaEntity(
 ) : BaseEntity() {
     override fun toString() = entityToString(*toStringProperties)
 
-    override fun equals(other: Any?) = entityEquals(other, AuthSessionJpaEntity::id, *equalsAndHashCodeProperties)
+    override fun equals(other: Any?) = entityEquals(other, AuthSessionJpaEntity::id)
 
-    override fun hashCode() = entityHashCode(AuthSessionJpaEntity::id, *equalsAndHashCodeProperties)
+    override fun hashCode() = entityHashCode(AuthSessionJpaEntity::id)
 
     companion object {
-        val toStringProperties = arrayOf(AuthSessionJpaEntity::id, AuthSessionJpaEntity::userId, AuthSessionJpaEntity::token)
-        val equalsAndHashCodeProperties =
-            arrayOf(
-                AuthSessionJpaEntity::id,
-                AuthSessionJpaEntity::userId,
-                AuthSessionJpaEntity::token,
-                AuthSessionJpaEntity::userAgent,
-                AuthSessionJpaEntity::ip,
-                AuthSessionJpaEntity::expiresAt,
-            )
+        val toStringProperties =
+            arrayOf(AuthSessionJpaEntity::id, AuthSessionJpaEntity::userId, AuthSessionJpaEntity::token)
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionJpaEntity.kt
@@ -1,0 +1,61 @@
+package grantly.user.adapter.out
+
+import grantly.common.entity.BaseEntity
+import grantly.common.entity.entityEquals
+import grantly.common.entity.entityHashCode
+import grantly.common.entity.entityToString
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.OffsetDateTime
+
+@Entity
+@Table(
+    name = "auth_session",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_user_id_token", columnNames = ["user_id", "token"]),
+    ],
+)
+class AuthSessionJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @Column(nullable = false, length = 255)
+    val token: String,
+    @Column(nullable = true, length = 100)
+    val userAgent: String? = null,
+    @Column(nullable = true, length = 45)
+    val ip: String? = null,
+    @Column(nullable = false)
+    val expiresAt: OffsetDateTime,
+    @Column(name = "user_id", nullable = false, updatable = false)
+    val userId: Long,
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id", updatable = false, insertable = false)
+    val user: UserJpaEntity? = null,
+) : BaseEntity() {
+    override fun toString() = entityToString(*toStringProperties)
+
+    override fun equals(other: Any?) = entityEquals(other, AuthSessionJpaEntity::id, *equalsAndHashCodeProperties)
+
+    override fun hashCode() = entityHashCode(AuthSessionJpaEntity::id, *equalsAndHashCodeProperties)
+
+    companion object {
+        val toStringProperties = arrayOf(AuthSessionJpaEntity::id, AuthSessionJpaEntity::userId, AuthSessionJpaEntity::token)
+        val equalsAndHashCodeProperties =
+            arrayOf(
+                AuthSessionJpaEntity::id,
+                AuthSessionJpaEntity::userId,
+                AuthSessionJpaEntity::token,
+                AuthSessionJpaEntity::userAgent,
+                AuthSessionJpaEntity::ip,
+                AuthSessionJpaEntity::expiresAt,
+            )
+    }
+}

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionJpaRepository.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionJpaRepository.kt
@@ -1,0 +1,10 @@
+package grantly.user.adapter.out
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface AuthSessionJpaRepository : JpaRepository<AuthSessionJpaEntity, Long> {
+    fun findByToken(token: String): Optional<AuthSessionJpaEntity>
+
+    fun findByUserId(userId: Long): Optional<AuthSessionJpaEntity>
+}

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionMapper.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionMapper.kt
@@ -1,0 +1,35 @@
+package grantly.user.adapter.out
+
+import grantly.common.entity.IsMapper
+import grantly.user.domain.AuthSession
+import org.springframework.stereotype.Component
+
+@Component
+class AuthSessionMapper : IsMapper<AuthSessionJpaEntity, AuthSession> {
+    override fun toDomain(entity: AuthSessionJpaEntity): AuthSession =
+        AuthSession(
+            id = entity.id ?: 0L,
+            userId = entity.userId,
+            ip = entity.ip,
+            token = entity.token,
+            userAgent = entity.userAgent,
+            expiresAt = entity.expiresAt,
+            createdAt = entity.createdAt,
+            modifiedAt = entity.modifiedAt,
+        )
+
+    override fun toEntity(domain: AuthSession): AuthSessionJpaEntity {
+        // TODO: 다른 exception?
+        val token = domain.token ?: throw IllegalArgumentException("Token cannot be null")
+        val expiresAt = domain.expiresAt ?: throw IllegalArgumentException("ExpiresAt cannot be null")
+
+        return AuthSessionJpaEntity(
+            id = if (domain.id == 0L) null else domain.id,
+            userId = domain.userId,
+            ip = domain.ip,
+            token = token,
+            expiresAt = expiresAt,
+            userAgent = domain.userAgent,
+        )
+    }
+}

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionMapper.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionMapper.kt
@@ -12,24 +12,21 @@ class AuthSessionMapper : IsMapper<AuthSessionJpaEntity, AuthSession> {
             userId = entity.userId,
             ip = entity.ip,
             token = entity.token,
+            csrfToken = entity.csrfToken,
             userAgent = entity.userAgent,
             expiresAt = entity.expiresAt,
             createdAt = entity.createdAt,
             modifiedAt = entity.modifiedAt,
         )
 
-    override fun toEntity(domain: AuthSession): AuthSessionJpaEntity {
-        // TODO: 다른 exception?
-        val token = domain.token ?: throw IllegalArgumentException("Token cannot be null")
-        val expiresAt = domain.expiresAt ?: throw IllegalArgumentException("ExpiresAt cannot be null")
-
-        return AuthSessionJpaEntity(
+    override fun toEntity(domain: AuthSession): AuthSessionJpaEntity =
+        AuthSessionJpaEntity(
             id = if (domain.id == 0L) null else domain.id,
             userId = domain.userId,
+            token = domain.token,
+            csrfToken = domain.csrfToken,
             ip = domain.ip,
-            token = token,
-            expiresAt = expiresAt,
             userAgent = domain.userAgent,
+            expiresAt = domain.expiresAt,
         )
-    }
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
@@ -11,13 +11,20 @@ class AuthSessionPersistenceAdapter(
     private val authSessionMapper: AuthSessionMapper,
 ) : AuthSessionRepository {
     override fun createAuthSession(session: AuthSession): AuthSession {
-        session.generateToken()
         val userEntity = authSessionJpaRepository.save(authSessionMapper.toEntity(session))
         return authSessionMapper.toDomain(userEntity)
     }
 
     override fun getSessionByUserId(userId: Long): AuthSession {
         val sessionEntity = authSessionJpaRepository.findByUserId(userId)
+        if (sessionEntity.isEmpty) {
+            throw EntityNotFoundException("AuthSession not found")
+        }
+        return authSessionMapper.toDomain(sessionEntity.get())
+    }
+
+    override fun getSessionByToken(token: String): AuthSession {
+        val sessionEntity = authSessionJpaRepository.findByToken(token)
         if (sessionEntity.isEmpty) {
             throw EntityNotFoundException("AuthSession not found")
         }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
@@ -1,0 +1,17 @@
+package grantly.user.adapter.out
+
+import grantly.common.annotations.PersistenceAdapter
+import grantly.user.application.port.out.AuthSessionRepository
+import grantly.user.domain.AuthSession
+
+@PersistenceAdapter
+class AuthSessionPersistenceAdapter(
+    private val authSessionJpaRepository: AuthSessionJpaRepository,
+    private val authSessionMapper: AuthSessionMapper,
+) : AuthSessionRepository {
+    override fun createAuthSession(session: AuthSession): AuthSession {
+        session.generateToken()
+        val userEntity = authSessionJpaRepository.save(authSessionMapper.toEntity(session))
+        return authSessionMapper.toDomain(userEntity)
+    }
+}

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
@@ -3,6 +3,7 @@ package grantly.user.adapter.out
 import grantly.common.annotations.PersistenceAdapter
 import grantly.user.application.port.out.AuthSessionRepository
 import grantly.user.domain.AuthSession
+import jakarta.persistence.EntityNotFoundException
 
 @PersistenceAdapter
 class AuthSessionPersistenceAdapter(
@@ -13,5 +14,13 @@ class AuthSessionPersistenceAdapter(
         session.generateToken()
         val userEntity = authSessionJpaRepository.save(authSessionMapper.toEntity(session))
         return authSessionMapper.toDomain(userEntity)
+    }
+
+    override fun getSessionByUserId(userId: Long): AuthSession {
+        val sessionEntity = authSessionJpaRepository.findByUserId(userId)
+        if (sessionEntity.isEmpty) {
+            throw EntityNotFoundException("AuthSession not found")
+        }
+        return authSessionMapper.toDomain(sessionEntity.get())
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/UserJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/UserJpaEntity.kt
@@ -28,14 +28,12 @@ class UserJpaEntity(
 ) : BaseEntity() {
     override fun toString() = entityToString(*toStringProperties)
 
-    override fun equals(other: Any?) = entityEquals(other, UserJpaEntity::id, *equalsAndHashCodeProperties)
+    override fun equals(other: Any?) = entityEquals(other, UserJpaEntity::id)
 
-    override fun hashCode() = entityHashCode(*equalsAndHashCodeProperties)
+    override fun hashCode() = entityHashCode(UserJpaEntity::id)
 
     companion object {
         // 사용할 프로퍼티 정의
         val toStringProperties = arrayOf(UserJpaEntity::id, UserJpaEntity::email)
-        val equalsAndHashCodeProperties =
-            arrayOf(UserJpaEntity::id, UserJpaEntity::email, UserJpaEntity::name)
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/dto/LoginResponse.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/dto/LoginResponse.kt
@@ -1,0 +1,5 @@
+package grantly.user.adapter.out.dto
+
+data class LoginResponse(
+    val token: String,
+)

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/dto/LoginResponse.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/dto/LoginResponse.kt
@@ -1,5 +1,0 @@
-package grantly.user.adapter.out.dto
-
-data class LoginResponse(
-    val token: String,
-)

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/EditProfileUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/EditProfileUseCase.kt
@@ -1,9 +1,7 @@
 package grantly.user.application.port.`in`
 
-import grantly.common.annotations.UseCase
 import grantly.user.domain.User
 
-@UseCase
 interface EditProfileUseCase {
     fun update(
         id: Long,

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/FindUserQuery.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/FindUserQuery.kt
@@ -1,9 +1,7 @@
 package grantly.user.application.port.`in`
 
-import grantly.common.annotations.UseCase
 import grantly.user.domain.User
 
-@UseCase
 interface FindUserQuery {
     fun findUserById(id: Long): User
 

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/LoginUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/LoginUseCase.kt
@@ -1,0 +1,12 @@
+package grantly.user.application.port.`in`
+
+import grantly.user.application.port.`in`.dto.LoginParams
+import grantly.user.domain.AuthSession
+import jakarta.servlet.http.HttpServletResponse
+
+interface LoginUseCase {
+    fun login(
+        params: LoginParams,
+        response: HttpServletResponse,
+    ): AuthSession
+}

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/LoginUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/LoginUseCase.kt
@@ -9,4 +9,9 @@ interface LoginUseCase {
         params: LoginParams,
         response: HttpServletResponse,
     ): AuthSession
+
+    fun setSessionCookie(
+        response: HttpServletResponse,
+        session: AuthSession,
+    )
 }

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/LoginUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/LoginUseCase.kt
@@ -9,9 +9,4 @@ interface LoginUseCase {
         params: LoginParams,
         response: HttpServletResponse,
     ): AuthSession
-
-    fun setSessionCookie(
-        response: HttpServletResponse,
-        session: AuthSession,
-    )
 }

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/SignUpUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/SignUpUseCase.kt
@@ -1,10 +1,8 @@
 package grantly.user.application.port.`in`
 
-import grantly.common.annotations.UseCase
 import grantly.user.application.port.`in`.dto.SignUpParams
 import grantly.user.domain.User
 
-@UseCase
 interface SignUpUseCase {
     fun signUp(params: SignUpParams): User
 }

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/dto/LoginParams.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/dto/LoginParams.kt
@@ -1,0 +1,8 @@
+package grantly.user.application.port.`in`.dto
+
+data class LoginParams(
+    val email: String,
+    val password: String,
+    val ip: String? = null,
+    val userAgent: String? = null,
+)

--- a/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
@@ -6,4 +6,6 @@ interface AuthSessionRepository {
     fun createAuthSession(session: AuthSession): AuthSession
 
     fun getSessionByUserId(userId: Long): AuthSession
+
+    fun getSessionByToken(token: String): AuthSession
 }

--- a/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
@@ -1,0 +1,7 @@
+package grantly.user.application.port.out
+
+import grantly.user.domain.AuthSession
+
+interface AuthSessionRepository {
+    fun createAuthSession(session: AuthSession): AuthSession
+}

--- a/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
@@ -4,4 +4,6 @@ import grantly.user.domain.AuthSession
 
 interface AuthSessionRepository {
     fun createAuthSession(session: AuthSession): AuthSession
+
+    fun getSessionByUserId(userId: Long): AuthSession
 }

--- a/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
@@ -3,19 +3,28 @@ package grantly.user.application.service
 import grantly.common.annotations.UseCase
 import grantly.user.application.port.`in`.EditProfileUseCase
 import grantly.user.application.port.`in`.FindUserQuery
+import grantly.user.application.port.`in`.LoginUseCase
 import grantly.user.application.port.`in`.SignUpUseCase
+import grantly.user.application.port.`in`.dto.LoginParams
 import grantly.user.application.port.`in`.dto.SignUpParams
+import grantly.user.application.port.out.AuthSessionRepository
 import grantly.user.application.port.out.UserRepository
 import grantly.user.application.service.exceptions.DuplicateEmailException
+import grantly.user.application.service.exceptions.PasswordMismatchException
+import grantly.user.domain.AuthSession
 import grantly.user.domain.User
 import jakarta.persistence.EntityNotFoundException
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.crypto.password.PasswordEncoder
 
 @UseCase
 class UserService(
     private val userRepository: UserRepository,
+    private val authSessionRepository: AuthSessionRepository,
     private val passwordEncoder: PasswordEncoder,
 ) : SignUpUseCase,
+    LoginUseCase,
     FindUserQuery,
     EditProfileUseCase {
     override fun signUp(params: SignUpParams): User {
@@ -28,6 +37,29 @@ class UserService(
             user.hashPassword(passwordEncoder)
             return userRepository.createUser(user)
         }
+    }
+
+    override fun login(
+        params: LoginParams,
+        response: HttpServletResponse,
+    ): AuthSession {
+        val user = findUserByEmail(params.email)
+        if (!user.checkPassword(passwordEncoder, params.password)) {
+            throw PasswordMismatchException()
+        }
+
+        var newSession: AuthSession
+        var session = AuthSession(userId = user.id, ip = params.ip, userAgent = params.userAgent)
+        while (true) {
+            try {
+                newSession = authSessionRepository.createAuthSession(session)
+                break
+            } catch (e: DataIntegrityViolationException) {
+                session.generateToken()
+            }
+        }
+        // TODO: request 객체에 httponly cookie 설정
+        return newSession
     }
 
     override fun findUserById(id: Long) = userRepository.getUser(id)

--- a/src/api/src/main/kotlin/grantly/user/application/service/exceptions/PasswordMismatchException.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/exceptions/PasswordMismatchException.kt
@@ -1,0 +1,3 @@
+package grantly.user.application.service.exceptions
+
+class PasswordMismatchException : RuntimeException("Password does not match")

--- a/src/api/src/main/kotlin/grantly/user/application/service/exceptions/TokenGenerationException.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/exceptions/TokenGenerationException.kt
@@ -1,0 +1,3 @@
+package grantly.user.application.service.exceptions
+
+class TokenGenerationException : RuntimeException("Failed to generate token")

--- a/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
+++ b/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
@@ -42,4 +42,6 @@ data class AuthSession(
 
         return token as String
     }
+
+    fun isValid(): Boolean = expiresAt?.isAfter(OffsetDateTime.now()) ?: false
 }

--- a/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
+++ b/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
@@ -1,47 +1,19 @@
 package grantly.user.domain
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
-import java.security.SecureRandom
 import java.time.OffsetDateTime
-import java.util.Base64
-import java.util.UUID
 
 @Schema(description = "세션 도메인 모델")
 data class AuthSession(
     val id: Long = 0L,
     val userId: Long,
-    var token: String? = null,
+    var token: String,
+    var csrfToken: String,
     val ip: String? = null,
     val userAgent: String? = null,
-    var expiresAt: OffsetDateTime? = null,
+    var expiresAt: OffsetDateTime,
     var createdAt: OffsetDateTime = OffsetDateTime.now(),
     var modifiedAt: OffsetDateTime? = null,
 ) {
-    private fun appendExpiresAt() {
-        expiresAt = OffsetDateTime.now().plusDays(1)
-    }
-
-    fun generateToken(): String {
-        val encoder = BCryptPasswordEncoder(12)
-
-        // UUID 생성 (중복 방지)
-        val uuid = UUID.randomUUID().toString()
-        // 랜덤 바이트 추가
-        val randomBytes = ByteArray(16)
-        SecureRandom().nextBytes(randomBytes)
-        val randomString = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes)
-        // UUID + 랜덤 문자열 조합
-        val rawToken = "$uuid-$randomString"
-        // 해싱
-        val bcryptHash = encoder.encode(rawToken)
-        // 255자 제한
-        token = bcryptHash.take(255)
-        // 만료일시 설정
-        appendExpiresAt()
-
-        return token as String
-    }
-
-    fun isValid(): Boolean = expiresAt?.isAfter(OffsetDateTime.now()) ?: false
+    fun isValid(): Boolean = expiresAt.isAfter(OffsetDateTime.now())
 }

--- a/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
+++ b/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
@@ -1,0 +1,45 @@
+package grantly.user.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import java.security.SecureRandom
+import java.time.OffsetDateTime
+import java.util.Base64
+import java.util.UUID
+
+@Schema(description = "세션 도메인 모델")
+data class AuthSession(
+    val id: Long = 0L,
+    val userId: Long,
+    var token: String? = null,
+    val ip: String? = null,
+    val userAgent: String? = null,
+    var expiresAt: OffsetDateTime? = null,
+    var createdAt: OffsetDateTime = OffsetDateTime.now(),
+    var modifiedAt: OffsetDateTime? = null,
+) {
+    private fun appendExpiresAt() {
+        expiresAt = OffsetDateTime.now().plusDays(1)
+    }
+
+    fun generateToken(): String {
+        val encoder = BCryptPasswordEncoder(12)
+
+        // UUID 생성 (중복 방지)
+        val uuid = UUID.randomUUID().toString()
+        // 랜덤 바이트 추가
+        val randomBytes = ByteArray(16)
+        SecureRandom().nextBytes(randomBytes)
+        val randomString = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes)
+        // UUID + 랜덤 문자열 조합
+        val rawToken = "$uuid-$randomString"
+        // 해싱
+        val bcryptHash = encoder.encode(rawToken)
+        // 255자 제한
+        token = bcryptHash.take(255)
+        // 만료일시 설정
+        appendExpiresAt()
+
+        return token as String
+    }
+}

--- a/src/api/src/main/kotlin/grantly/user/domain/User.kt
+++ b/src/api/src/main/kotlin/grantly/user/domain/User.kt
@@ -17,4 +17,12 @@ data class User(
     fun hashPassword(passwordEncoder: PasswordEncoder) {
         password = passwordEncoder.encode(password)
     }
+
+    fun checkPassword(
+        passwordEncoder: PasswordEncoder,
+        rawPassword: String,
+    ): Boolean =
+        password?.let {
+            passwordEncoder.matches(rawPassword, it)
+        } ?: false
 }

--- a/src/api/src/main/resources/application.yml
+++ b/src/api/src/main/resources/application.yml
@@ -33,7 +33,12 @@ springdoc:
   show-actuator: true
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
-
+grantly:
+  auth:
+    token:
+      key: session_token
+  cookie:
+    domain: .grantly.work
 ---
 spring:
   config:
@@ -42,7 +47,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-
+grantly:
+  cookie:
+    domain: api.grantly.work
 ---
 spring:
   config:
@@ -51,3 +58,4 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+

--- a/src/api/src/main/resources/application.yml
+++ b/src/api/src/main/resources/application.yml
@@ -34,9 +34,6 @@ springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
 grantly:
-  auth:
-    token:
-      key: session_token
   cookie:
     domain: .grantly.work
 ---

--- a/src/api/src/main/resources/migrations/V2__add_auth_session_table.sql
+++ b/src/api/src/main/resources/migrations/V2__add_auth_session_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE auth_session
+(
+    id          BIGINT AUTO_INCREMENT NOT NULL,
+    created_at  datetime     NOT NULL,
+    modified_at datetime     NOT NULL,
+    token       VARCHAR(255) NOT NULL,
+    user_agent  VARCHAR(100) NULL,
+    ip          VARCHAR(45) NULL,
+    expires_at  datetime     NOT NULL,
+    user_id     BIGINT       NOT NULL,
+    CONSTRAINT pk_auth_session PRIMARY KEY (id)
+);
+
+ALTER TABLE auth_session
+    ADD CONSTRAINT uq_user_id_token UNIQUE (user_id, token);
+
+ALTER TABLE auth_session
+    ADD CONSTRAINT FK_AUTH_SESSION_ON_USER FOREIGN KEY (user_id) REFERENCES user (id);

--- a/src/api/src/main/resources/migrations/V2__add_auth_session_table.sql
+++ b/src/api/src/main/resources/migrations/V2__add_auth_session_table.sql
@@ -1,18 +1,19 @@
 CREATE TABLE auth_session
 (
     id          BIGINT AUTO_INCREMENT NOT NULL,
-    created_at  datetime     NOT NULL,
-    modified_at datetime     NOT NULL,
-    token       VARCHAR(255) NOT NULL,
-    user_agent  VARCHAR(100) NULL,
-    ip          VARCHAR(45) NULL,
-    expires_at  datetime     NOT NULL,
-    user_id     BIGINT       NOT NULL,
+    created_at  datetime              NOT NULL,
+    modified_at datetime              NOT NULL,
+    token       VARCHAR(50)           NOT NULL,
+    csrf_token  VARCHAR(50)           NOT NULL,
+    user_agent  VARCHAR(255)          NULL,
+    ip          VARCHAR(45)           NULL,
+    expires_at  datetime              NOT NULL,
+    user_id     BIGINT                NOT NULL,
     CONSTRAINT pk_auth_session PRIMARY KEY (id)
 );
 
 ALTER TABLE auth_session
-    ADD CONSTRAINT uq_user_id_token UNIQUE (user_id, token);
+    ADD CONSTRAINT uc_auth_session_token UNIQUE (token);
 
 ALTER TABLE auth_session
     ADD CONSTRAINT FK_AUTH_SESSION_ON_USER FOREIGN KEY (user_id) REFERENCES user (id);

--- a/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
@@ -1,6 +1,7 @@
 package grantly.user.adapter.`in`
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import grantly.common.constants.AuthConstants
 import grantly.user.adapter.`in`.dto.LoginRequest
 import grantly.user.adapter.`in`.dto.SignUpRequest
 import grantly.user.application.port.out.UserRepository
@@ -40,8 +41,6 @@ class AuthControllerTest(
     @Autowired
     private val passwordEncoder: BCryptPasswordEncoder,
 ) {
-    private val sessionTokenKey: String by lazy { env.getProperty("grantly.auth.token.key", "") }
-
     private lateinit var existingUser: User
 
     @BeforeAll
@@ -98,19 +97,19 @@ class AuthControllerTest(
 
     @Test
     @DisplayName("로그인 성공")
-    fun `should return 200 when login is successful`() {
+    fun `should return 204 when login is successful`() {
         // given
         val jsonBody = objectMapper.writeValueAsString(LoginRequest(existingUser.email, "test123!"))
 
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/token")
+                post("/v1/auth/login")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.token").exists())
-            .andExpect(cookie().exists(sessionTokenKey))
+            ).andExpect(status().isNoContent)
+            .andExpect(cookie().exists(AuthConstants.SESSION_COOKIE_NAME))
+            .andExpect(cookie().exists(AuthConstants.CSRF_COOKIE_NAME))
     }
 
     @Test
@@ -122,7 +121,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/token")
+                post("/v1/auth/login")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isUnauthorized)
@@ -137,7 +136,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/token")
+                post("/v1/auth/login")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isUnauthorized)

--- a/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
@@ -128,6 +128,21 @@ class AuthControllerTest(
             ).andExpect(status().isUnauthorized)
     }
 
+    @Test
+    @DisplayName("로그인 실패: 존재하지 않는 유저")
+    fun `should return 401 when user does not exist`() {
+        // given
+        val jsonBody = objectMapper.writeValueAsString(LoginRequest("invalid@email.com", "somepassword1234!"))
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/v1/auth/token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonBody),
+            ).andExpect(status().isUnauthorized)
+    }
+
     fun createTestUser(
         email: String,
         name: String,

--- a/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
@@ -1,19 +1,25 @@
 package grantly.user.adapter.`in`
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import grantly.user.adapter.`in`.dto.LoginRequest
 import grantly.user.adapter.`in`.dto.SignUpRequest
 import grantly.user.application.port.out.UserRepository
 import grantly.user.domain.User
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.core.env.Environment
 import org.springframework.http.MediaType
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -21,6 +27,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AuthControllerTest(
     @Autowired
     private val userRepository: UserRepository,
@@ -28,14 +35,23 @@ class AuthControllerTest(
     private val mockMvc: MockMvc,
     @Autowired
     private val objectMapper: ObjectMapper,
+    @Autowired
+    private val env: Environment,
+    @Autowired
+    private val passwordEncoder: BCryptPasswordEncoder,
 ) {
+    private val sessionTokenKey: String by lazy { env.getProperty("grantly.auth.token.key", "") }
+
+    private lateinit var existingUser: User
+
+    @BeforeAll
+    fun setUp() {
+        existingUser = createTestUser("test@email.com", "test", "test123!")
+    }
+
     @Test
     @DisplayName("중복 이메일로 회원가입 불가")
     fun `should return 409 when email is already taken`() {
-        // given
-        val existingUser = User(email = "test@email.com", name = "test", password = "test123!")
-        userRepository.createUser(existingUser)
-
         // when & then
         val jsonBody = objectMapper.writeValueAsString(SignUpRequest(existingUser.email, "test2", "test123!"))
         mockMvc
@@ -78,5 +94,47 @@ class AuthControllerTest(
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isUnprocessableEntity)
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    fun `should return 200 when login is successful`() {
+        // given
+        val jsonBody = objectMapper.writeValueAsString(LoginRequest(existingUser.email, "test123!"))
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/v1/auth/token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonBody),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.token").exists())
+            .andExpect(cookie().exists(sessionTokenKey))
+    }
+
+    @Test
+    @DisplayName("로그인 실패: 비밀번호 불일치")
+    fun `should return 401 when password is incorrect`() {
+        // given
+        val jsonBody = objectMapper.writeValueAsString(LoginRequest(existingUser.email, "wrong-password"))
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/v1/auth/token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonBody),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    fun createTestUser(
+        email: String,
+        name: String,
+        password: String,
+    ): User {
+        val user = User(email = email, name = name, password = password)
+        user.hashPassword(passwordEncoder)
+        return userRepository.createUser(user)
     }
 }

--- a/src/api/src/test/resources/application-test.yml
+++ b/src/api/src/test/resources/application-test.yml
@@ -25,3 +25,6 @@ spring:
   h2:
     console:
       enabled: true
+grantly:
+  cookie:
+    domain: localhost


### PR DESCRIPTION
## 변경내역
- 세션 토큰을 기반으로 한 이메일 로그인 API


resolves #28, resolves #29, resolves #39

## 확인이 필요한 부분
- 아래 작업들은 포함되지 않았습니다.
    - #30 
    - 다른 user agent 로 로그인 시, 기존 토큰 만료 처리 및 새로운 토큰 발급
- 찾아보니 JpaEntity 의 equals(), hashcode() 판단할 때 주로 id 만 기준으로 하는 경우가 많다하여 이 커밋[7041bb8a72eb07b7c29c9869006d156e61ec2ce4] 에서 수정해보았습니다. 실제로 id 만 기준으로 하나요?
- 세션 검증과 csrf 토큰 검증을 위해서 기본 csrf 기능은 비활성화하고 커스텀 필터로 처리했습니다.
- csrf 토큰은 session 테이블에 같이 저장했습니다. spring security 기본 설정에서는 메모리로 관리하는 것 같긴 하나, 세션 토큰 검증을 위해 db 를 조회해야하니 일단은 함께 저장하도록 했습니다.

## 배포 전 해야 할 일
- [ ] auth_session table 에 대한 migration 이 요구됩니다.

### DB schema change
- [ ] `V2__add_auth_session_table.sql`

## 배포 후 해야 할 일

- [ ]

### DB schema change

- [ ]
