### PR TITLE
세션 토큰과 CSRF 토큰에 대한 Security Filter 추가

### DIFF
--- a/src/api/src/main/kotlin/grantly/config/AuthenticatedUser.kt
+++ b/src/api/src/main/kotlin/grantly/config/AuthenticatedUser.kt
@@ -1,0 +1,22 @@
+package grantly.config
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class AuthenticatedUser(
+    private val id: Long,
+    private val name: String,
+    private val email: String,
+) : UserDetails {
+    override fun getAuthorities() = emptyList<GrantedAuthority>()
+
+    override fun getPassword() = null
+
+    override fun getUsername(): String = name
+
+    fun getId(): Long = id
+
+    fun getEmail(): String = email
+
+    override fun isEnabled(): Boolean = true
+}

--- a/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
+++ b/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
@@ -1,8 +1,13 @@
 package grantly.config
 
+import grantly.config.filter.CsrfValidationFilter
 import grantly.config.filter.SessionContext
+import grantly.config.filter.SessionValidationFilter
+import grantly.user.application.port.out.UserRepository
+import grantly.user.application.service.SessionService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -21,7 +26,14 @@ import java.security.SecureRandom
 class SecurityConfig(
     private val redisTemplate: StringRedisTemplate,
     private val sessionContext: SessionContext,
+    private val sessionService: SessionService,
+    private val userRepository: UserRepository,
 ) {
+    companion object {
+        private const val ORDER_PUBLIC_FILTER = 1
+        private const val ORDER_SECURE_FILTER = 2
+    }
+
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder(12, SecureRandom())
 
@@ -29,16 +41,37 @@ class SecurityConfig(
     fun csrfTokenRepository(): CsrfTokenRepository = RedisCsrfTokenRepository(redisTemplate)
 
     @Bean
-    fun securityFilterChainDSL(http: HttpSecurity): SecurityFilterChain {
+    @Order(ORDER_PUBLIC_FILTER)
+    fun publicFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
-            .csrf { it.disable() }
-            .cors { }
-            .authorizeHttpRequests { auth ->
-                auth
-                    .anyRequest()
-                    .permitAll()
-            }.addFilterBefore(sessionContext, UsernamePasswordAuthenticationFilter::class.java)
+            .securityMatcher(
+                "/v*/auth/login",
+                "/v*/auth/signup",
+                "/v*/auth/csrf-token",
+                "/docs/**",
+            ).authorizeHttpRequests { it.anyRequest().permitAll() }
+            .addFilterBefore(sessionContext, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterAfter(
+                CsrfValidationFilter(csrfTokenRepository()),
+                UsernamePasswordAuthenticationFilter::class.java,
+            ).csrf { it.disable() }
+        return http.build()
+    }
 
+    @Bean
+    @Order(ORDER_SECURE_FILTER)
+    fun secureFilterChain(http: HttpSecurity): SecurityFilterChain {
+        // SessionContext -> CsrfValidationFilter -> SessionValidationFilter
+        http
+            .authorizeHttpRequests { it.anyRequest().authenticated() }
+            .addFilterBefore(sessionContext, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterAfter(
+                CsrfValidationFilter(csrfTokenRepository()),
+                UsernamePasswordAuthenticationFilter::class.java,
+            ).addFilterAfter(
+                SessionValidationFilter(sessionService, userRepository),
+                UsernamePasswordAuthenticationFilter::class.java,
+            ).csrf { it.disable() }
         return http.build()
     }
 

--- a/src/api/src/main/kotlin/grantly/config/filter/CsrfValidationFilter.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/CsrfValidationFilter.kt
@@ -1,0 +1,53 @@
+package grantly.config.filter
+
+import grantly.common.constants.AuthConstants
+import grantly.common.exceptions.HttpUnauthorizedException
+import grantly.common.utils.HttpUtil
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.web.csrf.CsrfTokenRepository
+import org.springframework.web.filter.OncePerRequestFilter
+
+class CsrfValidationFilter(
+    private val csrfTokenRepository: CsrfTokenRepository,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        // unsafe method 인가
+        if (!isUnsafeMethod(request)) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        // CSRF 토큰이 존재하는가
+        val csrfTokenHeader =
+            request.getHeader(AuthConstants.CSRF_HEADER_NAME) ?: run {
+                HttpUtil.writeErrorResponse(response, HttpUnauthorizedException("CSRF token header not found"))
+                return
+            }
+
+        // CSRF 토큰이 쿠키에 존재하고 registry 에서 조회 가능한가
+        val savedCsrfToken =
+            csrfTokenRepository.loadToken(request)
+                ?: run {
+                    HttpUtil.writeErrorResponse(response, HttpUnauthorizedException("CSRF token not found"))
+                    return
+                }
+
+        // CSRF 토큰이 일치하는가
+        if (csrfTokenHeader != savedCsrfToken.token) {
+            HttpUtil.writeErrorResponse(response, HttpUnauthorizedException("CSRF token mismatch"))
+            return
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun isUnsafeMethod(request: HttpServletRequest): Boolean {
+        val unsafeMethods = listOf("POST", "PUT", "DELETE", "PATCH")
+        return unsafeMethods.contains(request.method)
+    }
+}

--- a/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
@@ -11,10 +11,8 @@ import grantly.user.domain.User
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
-@Component
 class SessionValidationFilter(
     private val sessionService: SessionService,
     private val userRepository: UserRepository,

--- a/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
@@ -1,0 +1,79 @@
+package grantly.config.filter
+
+import grantly.common.constants.AuthConstants
+import grantly.common.exceptions.HttpUnauthorizedException
+import grantly.common.utils.HttpUtil
+import grantly.config.AuthenticatedUser
+import grantly.user.application.port.out.UserRepository
+import grantly.user.application.service.SessionService
+import grantly.user.domain.AuthSession
+import grantly.user.domain.User
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class SessionValidationFilter(
+    private val sessionService: SessionService,
+    private val userRepository: UserRepository,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: jakarta.servlet.http.HttpServletRequest,
+        response: jakarta.servlet.http.HttpServletResponse,
+        filterChain: jakarta.servlet.FilterChain,
+    ) {
+        // HttpSession 이 request 에 존재하는지 확인
+        val httpSession =
+            sessionService.getHttpSession(request) ?: run {
+                HttpUtil.writeErrorResponse(response, HttpUnauthorizedException())
+                return
+            }
+
+        val authSession: AuthSession
+        try {
+            authSession = sessionService.findSessionByToken(httpSession.token)
+        } catch (e: EntityNotFoundException) {
+            HttpUtil.writeErrorResponse(response, HttpUnauthorizedException())
+            return
+        }
+        // 익명세션이 아닌지 확인
+        if (authSession.isAnonymous()) {
+            HttpUtil.writeErrorResponse(response, HttpUnauthorizedException())
+            return
+        }
+        // 세션이 만료되었는지 확인
+        if (!authSession.isValid()) {
+            HttpUtil.writeErrorResponse(response, HttpUnauthorizedException())
+            return
+        }
+
+        // Security Context 설정
+        val user: User
+        try {
+            // 유저 정보 조회
+            user = userRepository.getUser(authSession.userId!!)
+        } catch (e: EntityNotFoundException) {
+            sessionService.delete(authSession.id)
+            // 세션 쿠키 삭제
+            HttpUtil.getCookie(request, AuthConstants.SESSION_COOKIE_NAME)?.let { cookie ->
+                HttpUtil.deleteCookie(response, cookie)
+            }
+            HttpUtil.writeErrorResponse(response, HttpUnauthorizedException("User not found"))
+            return
+        }
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(
+                AuthenticatedUser(
+                    id = user.id,
+                    name = user.name,
+                    email = user.email,
+                ),
+                null,
+                emptyList(), // TODO: 추후 member 와 user 의 Role 구분?
+            )
+        // 다음 필터로 진행
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
@@ -83,8 +83,8 @@ class SessionService(
         request.setAttribute(AuthConstants.SESSION_ATTR, httpSession)
     }
 
-    fun getHttpSession(request: HttpServletRequest): CustomHttpSession =
-        request.getAttribute(AuthConstants.SESSION_ATTR) as CustomHttpSession
+    fun getHttpSession(request: HttpServletRequest): CustomHttpSession? =
+        request.getAttribute(AuthConstants.SESSION_ATTR) as? CustomHttpSession
 
     fun persist(request: HttpServletRequest): AuthSession {
         val httpSession = request.getAttribute(AuthConstants.SESSION_ATTR) as CustomHttpSession

--- a/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
@@ -42,7 +42,7 @@ class UserService(
             throw PasswordMismatchException()
         }
 
-        val httpSession = sessionService.getHttpSession(params.request)
+        val httpSession = sessionService.getHttpSession(params.request) ?: throw EntityNotFoundException("Session not found")
         val authSession = sessionService.findSessionByToken(httpSession.token)
 
         if (!authSession.isValid()) {

--- a/src/api/src/main/resources/application.yml
+++ b/src/api/src/main/resources/application.yml
@@ -60,9 +60,10 @@ spring:
   config:
     activate:
       on-profile: prod
-  redis:
-    host: ${SPRING_REDIS_HOST}
-    port: ${SPRING_REDIS_PORT}
+  data:
+    redis:
+      host: ${SPRING_REDIS_HOST}
+      port: ${SPRING_REDIS_PORT}
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}

--- a/src/api/src/main/resources/application.yml
+++ b/src/api/src/main/resources/application.yml
@@ -52,6 +52,9 @@ spring:
 grantly:
   cookie:
     domain: api.grantly.work
+logging:
+  level:
+    org.springframework.web.servlet.DispatcherServlet: DEBUG
 ---
 spring:
   config:


### PR DESCRIPTION
## 변경내역
- SessionValidationFilter
- CsrfValidationFilter (test profile 에서는 비활성화)
- Filter chain bean 분리

## 확인이 필요한 부분
- ~~/login 액션에서 불필요하게 CSRF token 을 set 해주고 있는 로직을 제거했습니다. (csrf token 의 추가는 /csrf-token 엔드포인트로만 수행할 수 있도록)~~
- ~~csrf token 을 redis 에 저장해둘 때 `csrf:$sessionToken` 를 Key 로 잡고 저장하는데, csrf token 요청 시 세션이 없을 수도 있으므로 CsrfTokenService.setCsrfToken 메서드에서 세션이 없으면 임시 토큰을 쿠키에 저장하고 이 세션값을 이용해 csrf token 을 저장하는 로직을 추가했습니다.~~
- 상용 application.yml 에서 redis port, host 값이 data 키 하위로 들어가야할 것 같아서 수정했습니다.

## 배포 전 해야 할 일

- [ ]

### DB schema change

- [ ]

## 배포 후 해야 할 일

- [ ]

### DB schema change

- [ ]
