### PR TITLE
SessionContext 미들웨어 추가 및 이에 따른 csrf, 로그인 로직 수정

### DIFF
--- a/src/api/src/main/kotlin/grantly/common/constants/AuthConstants.kt
+++ b/src/api/src/main/kotlin/grantly/common/constants/AuthConstants.kt
@@ -7,4 +7,5 @@ object AuthConstants {
     const val SESSION_TOKEN_EXPIRATION = 60 * 60 * 24L // 24 hours
     const val CSRF_TOKEN_EXPIRATION = 60 * 5L // 5 minutes
     const val DEVICE_ID_COOKIE_NAME = "device_id"
+    const val SESSION_ATTR = "session"
 }

--- a/src/api/src/main/kotlin/grantly/common/utils/HttpUtil.kt
+++ b/src/api/src/main/kotlin/grantly/common/utils/HttpUtil.kt
@@ -38,13 +38,13 @@ class HttpUtil {
     ) {
         private val cookie = Cookie(name, value)
 
-        fun maxAge(maxAge: Int) = apply { cookie.maxAge }
+        fun maxAge(maxAge: Int) = apply { cookie.maxAge = maxAge }
 
-        fun domain(domain: String) = apply { cookie.domain ?: domain }
+        fun domain(domain: String) = apply { cookie.domain = domain }
 
-        fun secure(secure: Boolean) = apply { cookie.secure }
+        fun secure(secure: Boolean) = apply { cookie.secure = secure }
 
-        fun httpOnly(httpOnly: Boolean) = apply { cookie.isHttpOnly }
+        fun httpOnly(httpOnly: Boolean) = apply { cookie.isHttpOnly = httpOnly }
 
         fun sameSite(sameSite: String) = apply { cookie.setAttribute("SameSite", sameSite) }
 

--- a/src/api/src/main/kotlin/grantly/config/CustomHttpSession.kt
+++ b/src/api/src/main/kotlin/grantly/config/CustomHttpSession.kt
@@ -1,0 +1,6 @@
+package grantly.config
+
+data class CustomHttpSession(
+    val token: String,
+    val deviceId: String,
+)

--- a/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
+++ b/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package grantly.config
 
+import grantly.config.filter.SessionContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -8,6 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.csrf.CsrfTokenRepository
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
@@ -18,6 +20,7 @@ import java.security.SecureRandom
 @EnableWebSecurity
 class SecurityConfig(
     private val redisTemplate: StringRedisTemplate,
+    private val sessionContext: SessionContext,
 ) {
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder(12, SecureRandom())
@@ -34,7 +37,7 @@ class SecurityConfig(
                 auth
                     .anyRequest()
                     .permitAll()
-            }
+            }.addFilterBefore(sessionContext, UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
     }

--- a/src/api/src/main/kotlin/grantly/config/filter/SessionContext.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/SessionContext.kt
@@ -1,0 +1,38 @@
+package grantly.config.filter
+
+import grantly.user.application.service.SessionService
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+val log = KotlinLogging.logger {}
+
+@Component
+class SessionContext(
+    private val sessionService: SessionService,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        var sessionToken = sessionService.getSessionTokenCookie(request)
+        if (sessionToken == null) {
+            val (token, expiresAt) = sessionService.generateSessionToken()
+            sessionToken = token
+            sessionService.setSessionToken(response, token, expiresAt)
+        }
+        var deviceId = sessionService.getDeviceIdCookie(request)
+        if (deviceId == null) {
+            deviceId = sessionService.generateDeviceId()
+            sessionService.setDeviceId(response, deviceId)
+        }
+        sessionService.setHttpSession(request, sessionToken, deviceId)
+        log.debug { "Session token: $sessionToken, Device ID: $deviceId" }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
@@ -153,7 +153,7 @@ class AuthController(
             .build(response)
 
         // set csrf token
-        val csrfToken = csrfTokenUseCase.setCsrfToken(request, response)
+        val csrfToken = csrfTokenUseCase.issueCsrfToken(request, response)
         HttpUtil
             .buildCookie(AuthConstants.CSRF_COOKIE_NAME, csrfToken.token)
             .maxAge(Duration.ofSeconds(AuthConstants.CSRF_TOKEN_EXPIRATION).seconds.toInt())
@@ -187,15 +187,7 @@ class AuthController(
         request: HttpServletRequest,
         response: HttpServletResponse,
     ): ResponseEntity<Void> {
-        val csrfToken = csrfTokenUseCase.setCsrfToken(request, response)
-        HttpUtil
-            .buildCookie(AuthConstants.CSRF_COOKIE_NAME, csrfToken.token)
-            .maxAge(Duration.ofSeconds(AuthConstants.CSRF_TOKEN_EXPIRATION).seconds.toInt())
-            .domain(cookieDomain)
-            .sameSite("Lax")
-            .secure(true)
-            .httpOnly(true)
-            .build(response)
+        csrfTokenUseCase.issueCsrfToken(request, response)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
@@ -1,9 +1,7 @@
 package grantly.user.adapter.`in`
 
-import grantly.common.constants.AuthConstants
 import grantly.common.exceptions.HttpConflictException
 import grantly.common.exceptions.HttpExceptionResponse
-import grantly.common.exceptions.HttpInternalServerErrorException
 import grantly.common.exceptions.HttpUnauthorizedException
 import grantly.common.utils.HttpUtil
 import grantly.common.utils.TimeUtil
@@ -18,8 +16,6 @@ import grantly.user.application.port.`in`.dto.LoginParams
 import grantly.user.application.port.`in`.dto.SignUpParams
 import grantly.user.application.service.exceptions.DuplicateEmailException
 import grantly.user.application.service.exceptions.PasswordMismatchException
-import grantly.user.application.service.exceptions.TokenGenerationException
-import grantly.user.domain.AuthSession
 import grantly.user.domain.User
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -38,8 +34,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
-import java.time.Duration
-import java.time.OffsetDateTime
 
 @RestController
 @ResponseBody
@@ -128,50 +122,13 @@ class AuthController(
         request: HttpServletRequest,
         response: HttpServletResponse,
     ): ResponseEntity<Void> {
-        val ip = request.remoteAddr
-        val userAgent = request.getHeader("User-Agent")
-        val deviceId = HttpUtil.getCookie(request, AuthConstants.DEVICE_ID_COOKIE_NAME)?.value
-        val session: AuthSession
         try {
-            session = loginUseCase.login(LoginParams(body.email, body.password, deviceId, ip, userAgent))
+            loginUseCase.login(LoginParams(body.email, body.password, request, response))
         } catch (e: EntityNotFoundException) {
-            throw HttpUnauthorizedException(e.message)
+            throw HttpUnauthorizedException("Authorization failed")
         } catch (e: PasswordMismatchException) {
             throw HttpUnauthorizedException(e.message)
-        } catch (e: TokenGenerationException) {
-            throw HttpInternalServerErrorException(e.message)
         }
-        // set session token
-        HttpUtil
-            .buildCookie(AuthConstants.SESSION_COOKIE_NAME, session.token)
-            .maxAge(
-                Duration.between(OffsetDateTime.now(), session.expiresAt).seconds.toInt(),
-            ).domain(cookieDomain)
-            .sameSite("Lax")
-            .secure(true)
-            .httpOnly(true)
-            .build(response)
-
-        // set csrf token
-        val csrfToken = csrfTokenUseCase.issueCsrfToken(request, response)
-        HttpUtil
-            .buildCookie(AuthConstants.CSRF_COOKIE_NAME, csrfToken.token)
-            .maxAge(Duration.ofSeconds(AuthConstants.CSRF_TOKEN_EXPIRATION).seconds.toInt())
-            .domain(cookieDomain)
-            .sameSite("Lax")
-            .secure(true)
-            .httpOnly(true)
-            .build(response)
-
-        // set device id
-        HttpUtil
-            .buildCookie(AuthConstants.DEVICE_ID_COOKIE_NAME, session.deviceId)
-            .maxAge(Integer.MAX_VALUE)
-            .domain(cookieDomain)
-            .sameSite("Lax")
-            .secure(true)
-            .httpOnly(true)
-            .build(response)
 
         return ResponseEntity.noContent().build()
     }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionJpaEntity.kt
@@ -32,10 +32,10 @@ class AuthSessionJpaEntity(
     val ip: String? = null,
     @Column(nullable = false)
     val expiresAt: OffsetDateTime,
-    @Column(name = "user_id", nullable = false, updatable = false)
-    val userId: Long,
+    @Column(name = "user_id", nullable = true)
+    val userId: Long? = null,
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id", updatable = false, insertable = false)
+    @JoinColumn(name = "user_id", nullable = true, referencedColumnName = "id", updatable = false, insertable = false)
     val user: UserJpaEntity? = null,
 ) : BaseEntity() {
     override fun toString() = entityToString(*toStringProperties)

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
@@ -10,7 +10,7 @@ class AuthSessionPersistenceAdapter(
     private val authSessionJpaRepository: AuthSessionJpaRepository,
     private val authSessionMapper: AuthSessionMapper,
 ) : AuthSessionRepository {
-    override fun upsertAuthSession(session: AuthSession): AuthSession {
+    override fun updateSession(session: AuthSession): AuthSession {
         val userEntity = authSessionJpaRepository.save(authSessionMapper.toEntity(session))
         return authSessionMapper.toDomain(userEntity)
     }
@@ -36,4 +36,6 @@ class AuthSessionPersistenceAdapter(
         val userEntity = authSessionJpaRepository.save(authSessionMapper.toEntity(newSession))
         return authSessionMapper.toDomain(userEntity)
     }
+
+    override fun deleteSession(id: Long) = authSessionJpaRepository.deleteById(id)
 }

--- a/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/out/AuthSessionPersistenceAdapter.kt
@@ -30,4 +30,10 @@ class AuthSessionPersistenceAdapter(
         }
         return authSessionMapper.toDomain(sessionEntity.get())
     }
+
+    override fun createSession(session: AuthSession): AuthSession {
+        val newSession = session.copy(id = 0L)
+        val userEntity = authSessionJpaRepository.save(authSessionMapper.toEntity(newSession))
+        return authSessionMapper.toDomain(userEntity)
+    }
 }

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/CsrfTokenUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/CsrfTokenUseCase.kt
@@ -5,7 +5,7 @@ import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.web.csrf.CsrfToken
 
 interface CsrfTokenUseCase {
-    fun setCsrfToken(
+    fun issueCsrfToken(
         request: HttpServletRequest,
         response: HttpServletResponse,
     ): CsrfToken

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/dto/LoginParams.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/dto/LoginParams.kt
@@ -1,9 +1,11 @@
 package grantly.user.application.port.`in`.dto
 
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
 data class LoginParams(
     val email: String,
     val password: String,
-    val deviceId: String?,
-    val ip: String?,
-    val userAgent: String?,
+    val request: HttpServletRequest,
+    val response: HttpServletResponse,
 )

--- a/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
@@ -8,4 +8,6 @@ interface AuthSessionRepository {
     fun getSessionByUserId(userId: Long): AuthSession
 
     fun getSessionByToken(token: String): AuthSession
+
+    fun createSession(session: AuthSession): AuthSession
 }

--- a/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/out/AuthSessionRepository.kt
@@ -3,11 +3,13 @@ package grantly.user.application.port.out
 import grantly.user.domain.AuthSession
 
 interface AuthSessionRepository {
-    fun upsertAuthSession(session: AuthSession): AuthSession
+    fun updateSession(session: AuthSession): AuthSession
 
     fun getSessionByUserId(userId: Long): AuthSession
 
     fun getSessionByToken(token: String): AuthSession
 
     fun createSession(session: AuthSession): AuthSession
+
+    fun deleteSession(id: Long)
 }

--- a/src/api/src/main/kotlin/grantly/user/application/service/CsrfTokenService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/CsrfTokenService.kt
@@ -1,23 +1,50 @@
 package grantly.user.application.service
 
 import grantly.common.annotations.UseCase
+import grantly.common.constants.AuthConstants
+import grantly.common.utils.HttpUtil
 import grantly.user.application.port.`in`.CsrfTokenUseCase
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.web.csrf.CsrfToken
 import org.springframework.security.web.csrf.CsrfTokenRepository
+import java.time.Duration
 
 @UseCase
 class CsrfTokenService(
     private val csrfTokenRepository: CsrfTokenRepository,
+    private val sessionService: SessionService,
 ) : CsrfTokenUseCase {
-    override fun setCsrfToken(
+    @Value("\${grantly.cookie.domain}")
+    private lateinit var cookieDomain: String
+
+    override fun issueCsrfToken(
         request: HttpServletRequest,
         response: HttpServletResponse,
     ): CsrfToken {
+        // csrf token 생성
         val csrfToken = csrfTokenRepository.generateToken(request)
         csrfTokenRepository.saveToken(csrfToken, request, response)
+        // 세션 토큰 영속화
+        sessionService.persist(request)
+        // csrf token 쿠키 설정
+        setCsrfTokenCookie(response, csrfToken)
 
         return csrfToken
+    }
+
+    fun setCsrfTokenCookie(
+        response: HttpServletResponse,
+        csrfToken: CsrfToken,
+    ) {
+        HttpUtil
+            .buildCookie(AuthConstants.CSRF_COOKIE_NAME, csrfToken.token)
+            .maxAge(Duration.ofSeconds(AuthConstants.CSRF_TOKEN_EXPIRATION).seconds.toInt())
+            .domain(cookieDomain)
+            .sameSite("Lax")
+            .secure(true)
+            .httpOnly(true)
+            .build(response)
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
@@ -105,7 +105,7 @@ class SessionService(
 
     fun findSessionByUserId(userId: Long): AuthSession = authSessionRepository.getSessionByUserId(userId)
 
-    fun deleteSession(id: Long) = authSessionRepository.deleteSession(id)
+    fun delete(id: Long) = authSessionRepository.deleteSession(id)
 
     fun update(authSession: AuthSession): AuthSession = authSessionRepository.updateSession(authSession)
 }

--- a/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
@@ -1,0 +1,84 @@
+package grantly.user.application.service
+
+import grantly.common.constants.AuthConstants
+import grantly.common.utils.HttpUtil
+import grantly.config.CustomHttpSession
+import grantly.user.application.port.out.AuthSessionRepository
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * 세션과 관련된 서비스.
+ */
+@Component
+class SessionService(
+    private val sessionRepository: AuthSessionRepository,
+) {
+    @Value("\${grantly.cookie.domain}")
+    private lateinit var cookieDomain: String
+
+    fun getSessionTokenCookie(request: HttpServletRequest): String? {
+        HttpUtil
+            .getCookie(request, AuthConstants.SESSION_COOKIE_NAME)
+            ?.let { cookie ->
+                return cookie.value
+            } ?: return null
+    }
+
+    fun getDeviceIdCookie(request: HttpServletRequest): String? {
+        HttpUtil
+            .getCookie(request, AuthConstants.DEVICE_ID_COOKIE_NAME)
+            ?.let { cookie ->
+                return cookie.value
+            } ?: return null
+    }
+
+    fun setSessionToken(
+        response: HttpServletResponse,
+        token: String,
+        expiresAt: OffsetDateTime,
+    ) {
+        HttpUtil
+            .buildCookie(AuthConstants.SESSION_COOKIE_NAME, token)
+            .maxAge(
+                Duration.between(OffsetDateTime.now(), expiresAt).seconds.toInt(),
+            ).domain(cookieDomain)
+            .sameSite("Lax")
+            .secure(true)
+            .httpOnly(true)
+            .build(response)
+    }
+
+    fun setDeviceId(
+        response: HttpServletResponse,
+        deviceId: String,
+    ) {
+        HttpUtil
+            .buildCookie(AuthConstants.DEVICE_ID_COOKIE_NAME, deviceId)
+            .maxAge(Integer.MAX_VALUE)
+            .domain(cookieDomain)
+            .sameSite("Lax")
+            .secure(true)
+            .httpOnly(true)
+            .build(response)
+    }
+
+    fun generateSessionToken(): Pair<String, OffsetDateTime> =
+        Pair(UUID.randomUUID().toString(), OffsetDateTime.now().plusSeconds(AuthConstants.SESSION_TOKEN_EXPIRATION))
+
+    fun generateDeviceId(): String = UUID.randomUUID().toString()
+
+    fun setHttpSession(
+        request: HttpServletRequest,
+        token: String,
+        deviceId: String,
+    ) {
+        val httpSession = CustomHttpSession(token, deviceId)
+        request.setAttribute(AuthConstants.SESSION_ATTR, httpSession)
+    }
+}

--- a/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
@@ -4,6 +4,7 @@ import grantly.common.constants.AuthConstants
 import grantly.common.utils.HttpUtil
 import grantly.config.CustomHttpSession
 import grantly.user.application.port.out.AuthSessionRepository
+import grantly.user.domain.AuthSession
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
@@ -80,5 +81,20 @@ class SessionService(
     ) {
         val httpSession = CustomHttpSession(token, deviceId)
         request.setAttribute(AuthConstants.SESSION_ATTR, httpSession)
+    }
+
+    fun persist(request: HttpServletRequest): AuthSession {
+        val httpSession = request.getAttribute(AuthConstants.SESSION_ATTR) as CustomHttpSession
+        val ip = request.remoteAddr
+        val userAgent = request.getHeader("User-Agent")
+        val authSession =
+            AuthSession(
+                token = httpSession.token,
+                deviceId = httpSession.deviceId,
+                expiresAt = OffsetDateTime.now().plusSeconds(AuthConstants.SESSION_TOKEN_EXPIRATION),
+                ip = ip,
+                userAgent = userAgent,
+            )
+        return sessionRepository.createSession(authSession)
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
@@ -83,6 +83,9 @@ class SessionService(
         request.setAttribute(AuthConstants.SESSION_ATTR, httpSession)
     }
 
+    fun getHttpSession(request: HttpServletRequest): CustomHttpSession =
+        request.getAttribute(AuthConstants.SESSION_ATTR) as CustomHttpSession
+
     fun persist(request: HttpServletRequest): AuthSession {
         val httpSession = request.getAttribute(AuthConstants.SESSION_ATTR) as CustomHttpSession
         val ip = request.remoteAddr

--- a/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
@@ -18,7 +18,7 @@ import java.util.UUID
  */
 @Component
 class SessionService(
-    private val sessionRepository: AuthSessionRepository,
+    private val authSessionRepository: AuthSessionRepository,
 ) {
     @Value("\${grantly.cookie.domain}")
     private lateinit var cookieDomain: String
@@ -98,6 +98,14 @@ class SessionService(
                 ip = ip,
                 userAgent = userAgent,
             )
-        return sessionRepository.createSession(authSession)
+        return authSessionRepository.createSession(authSession)
     }
+
+    fun findSessionByToken(token: String): AuthSession = authSessionRepository.getSessionByToken(token)
+
+    fun findSessionByUserId(userId: Long): AuthSession = authSessionRepository.getSessionByUserId(userId)
+
+    fun deleteSession(id: Long) = authSessionRepository.deleteSession(id)
+
+    fun update(authSession: AuthSession): AuthSession = authSessionRepository.updateSession(authSession)
 }

--- a/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
@@ -46,7 +46,7 @@ class UserService(
         val authSession = sessionService.findSessionByToken(httpSession.token)
 
         if (!authSession.isValid()) {
-            sessionService.deleteSession(authSession.id)
+            sessionService.delete(authSession.id)
             throw EntityNotFoundException("Valid session not found")
         }
 
@@ -55,7 +55,7 @@ class UserService(
             try {
                 val existingUserSession = sessionService.findSessionByUserId(user.id)
                 // 이미 로그인된 세션이 있는 경우 제거함
-                sessionService.deleteSession(existingUserSession.id)
+                sessionService.delete(existingUserSession.id)
             } catch (e: EntityNotFoundException) {
                 // do nothing
             }

--- a/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
@@ -1,31 +1,23 @@
 package grantly.user.application.service
 
 import grantly.common.annotations.UseCase
-import grantly.common.constants.AuthConstants
 import grantly.user.application.port.`in`.EditProfileUseCase
 import grantly.user.application.port.`in`.FindUserQuery
 import grantly.user.application.port.`in`.LoginUseCase
 import grantly.user.application.port.`in`.SignUpUseCase
 import grantly.user.application.port.`in`.dto.LoginParams
 import grantly.user.application.port.`in`.dto.SignUpParams
-import grantly.user.application.port.out.AuthSessionRepository
 import grantly.user.application.port.out.UserRepository
 import grantly.user.application.service.exceptions.DuplicateEmailException
 import grantly.user.application.service.exceptions.PasswordMismatchException
 import grantly.user.domain.AuthSession
 import grantly.user.domain.User
 import jakarta.persistence.EntityNotFoundException
-import mu.KotlinLogging
 import org.springframework.security.crypto.password.PasswordEncoder
-import java.time.OffsetDateTime
-import java.util.UUID
-
-private val log = KotlinLogging.logger {}
 
 @UseCase
 class UserService(
     private val userRepository: UserRepository,
-    private val authSessionRepository: AuthSessionRepository,
     private val passwordEncoder: PasswordEncoder,
     private val sessionService: SessionService,
 ) : SignUpUseCase,
@@ -51,19 +43,19 @@ class UserService(
         }
 
         val httpSession = sessionService.getHttpSession(params.request)
-        val authSession = authSessionRepository.getSessionByToken(httpSession.token)
+        val authSession = sessionService.findSessionByToken(httpSession.token)
 
         if (!authSession.isValid()) {
-            authSessionRepository.deleteSession(authSession.id)
+            sessionService.deleteSession(authSession.id)
             throw EntityNotFoundException("Valid session not found")
         }
 
         // 익명 세션으로 요청이 들어온 경우, 현재 유저와 연결된 세션이 있는지 확인
         if (authSession.isAnonymous()) {
             try {
-                val existingUserSession = authSessionRepository.getSessionByUserId(user.id)
+                val existingUserSession = sessionService.findSessionByUserId(user.id)
                 // 이미 로그인된 세션이 있는 경우 제거함
-                authSessionRepository.deleteSession(existingUserSession.id)
+                sessionService.deleteSession(existingUserSession.id)
             } catch (e: EntityNotFoundException) {
                 // do nothing
             }
@@ -81,7 +73,7 @@ class UserService(
         // 유저와 연결
         authSession.connectUser(user.id)
 
-        val updatedSession = authSessionRepository.updateSession(authSession)
+        val updatedSession = sessionService.update(authSession)
 
         // 세션 토큰을 쿠키에 설정
         sessionService.setSessionToken(
@@ -92,50 +84,6 @@ class UserService(
         // 디바이스 ID를 쿠키에 설정
         sessionService.setDeviceId(params.response, updatedSession.deviceId)
         return updatedSession
-    }
-
-    /**
-     * 세션 토큰 생성
-     * @return 생성된 세션 토큰과 만료 시각
-     */
-    private fun generateToken(): Pair<String, OffsetDateTime> =
-        Pair(UUID.randomUUID().toString(), OffsetDateTime.now().plusSeconds(AuthConstants.SESSION_TOKEN_EXPIRATION))
-
-    private fun buildNewSession(
-        userId: Long,
-        ip: String?,
-        userAgent: String?,
-    ): AuthSession {
-        val (token, expiresAt) = generateToken()
-        return AuthSession(
-            userId = userId,
-            token = token,
-            deviceId = UUID.randomUUID().toString(),
-            ip = ip,
-            userAgent = userAgent,
-            expiresAt = expiresAt,
-        )
-    }
-
-    /**
-     * 세션 갱신.
-     * 기존 세션이 유효한데 deviceId 가 다르거나 없는 경우, 기존 세션이 만료된 경우를 처리한다.
-     * @return 갱신된 세션
-     */
-    private fun refreshSession(
-        existing: AuthSession,
-        deviceId: String?,
-        ip: String?,
-        userAgent: String?,
-    ): AuthSession {
-        val (token, expiresAt) = generateToken()
-        return existing.copy(
-            token = token,
-            deviceId = deviceId ?: UUID.randomUUID().toString(),
-            ip = ip,
-            userAgent = userAgent,
-            expiresAt = expiresAt,
-        )
     }
 
     override fun findUserById(id: Long) = userRepository.getUser(id)

--- a/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
+++ b/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
@@ -6,14 +6,38 @@ import java.time.OffsetDateTime
 @Schema(description = "세션 도메인 모델")
 data class AuthSession(
     val id: Long = 0L,
-    val userId: Long? = null,
+    var userId: Long? = null,
     var token: String,
-    val deviceId: String,
-    val ip: String? = null,
-    val userAgent: String? = null,
+    var deviceId: String,
+    var ip: String? = null,
+    var userAgent: String? = null,
     var expiresAt: OffsetDateTime,
     var createdAt: OffsetDateTime = OffsetDateTime.now(),
     var modifiedAt: OffsetDateTime? = null,
 ) {
     fun isValid(): Boolean = expiresAt.isAfter(OffsetDateTime.now())
+
+    fun isAnonymous(): Boolean = userId == null
+
+    fun updateMeta(
+        ip: String?,
+        userAgent: String?,
+        deviceId: String?,
+    ) {
+        this.ip = ip ?: this.ip
+        this.userAgent = userAgent ?: this.userAgent
+        this.deviceId = deviceId ?: this.deviceId
+    }
+
+    fun connectUser(userId: Long) {
+        this.userId = userId
+    }
+
+    fun replaceToken(
+        value: String,
+        expiresAt: OffsetDateTime,
+    ) {
+        token = value
+        this.expiresAt = expiresAt
+    }
 }

--- a/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
+++ b/src/api/src/main/kotlin/grantly/user/domain/AuthSession.kt
@@ -6,7 +6,7 @@ import java.time.OffsetDateTime
 @Schema(description = "세션 도메인 모델")
 data class AuthSession(
     val id: Long = 0L,
-    val userId: Long,
+    val userId: Long? = null,
     var token: String,
     val deviceId: String,
     val ip: String? = null,

--- a/src/api/src/main/resources/migrations/V3__auth_session_user_id_nullable.sql
+++ b/src/api/src/main/resources/migrations/V3__auth_session_user_id_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE auth_session
+    MODIFY user_id BIGINT NULL;


### PR DESCRIPTION
## 변경내역
- CustomHttpSession / SessionContext 미들웨어 도입
- SessionService 추가 (도메인 로직이라고 할만한 부분이 없는 것 같아 use case 는 만들지 않았습니다.)
- CsrfTokenService.issueCsrfToken -> CustomHttpSession 사용하도록 수정
- UserService.login -> CustomHttpSession 과 미리 만들어둔 익명 세션 사용하여 유저 연결하는 방식으로 수정

## 확인이 필요한 부분
- Secure API, Public API 요청에 대한 필터는 다른 PR 에서 다루겠습니다.

## 배포 전 해야 할 일

- [ ] 

### DB schema change

- [ ] auth_session.user_id 가 nullable 하게 변경되었습니다. (V3)

## 배포 후 해야 할 일

- [ ]

### DB schema change

- [ ]
