### PR TITLE
로그아웃 API

### DIFF
--- a/src/api/src/main/kotlin/grantly/common/utils/HttpUtil.kt
+++ b/src/api/src/main/kotlin/grantly/common/utils/HttpUtil.kt
@@ -38,6 +38,7 @@ class HttpUtil {
             response: HttpServletResponse,
             cookie: Cookie,
         ) {
+            cookie.value = null
             cookie.maxAge = 0
             response.addCookie(cookie)
         }

--- a/src/api/src/main/kotlin/grantly/common/utils/HttpUtil.kt
+++ b/src/api/src/main/kotlin/grantly/common/utils/HttpUtil.kt
@@ -34,15 +34,6 @@ class HttpUtil {
             key: String,
         ): Cookie? = request.cookies?.firstOrNull { it.name == key }
 
-        fun deleteCookie(
-            response: HttpServletResponse,
-            cookie: Cookie,
-        ) {
-            cookie.value = null
-            cookie.maxAge = 0
-            response.addCookie(cookie)
-        }
-
         fun writeErrorResponse(
             response: HttpServletResponse,
             exc: HttpException,

--- a/src/api/src/main/kotlin/grantly/config/CustomHttpSession.kt
+++ b/src/api/src/main/kotlin/grantly/config/CustomHttpSession.kt
@@ -1,6 +1,9 @@
 package grantly.config
 
+import java.time.OffsetDateTime
+
 data class CustomHttpSession(
     val token: String,
+    val expiresAt: OffsetDateTime,
     val deviceId: String,
 )

--- a/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
+++ b/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
@@ -81,9 +81,6 @@ class SecurityConfig(
         }
         http
             .addFilterAfter(
-                CsrfValidationFilter(csrfTokenRepository()),
-                UsernamePasswordAuthenticationFilter::class.java,
-            ).addFilterAfter(
                 SessionValidationFilter(sessionService, userRepository),
                 UsernamePasswordAuthenticationFilter::class.java,
             ).csrf { it.disable() }

--- a/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
@@ -24,10 +24,7 @@ class SessionValidationFilter(
     ) {
         // HttpSession 이 request 에 존재하는지 확인
         val httpSession =
-            sessionService.getHttpSession(request) ?: run {
-                HttpUtil.writeErrorResponse(response, HttpUnauthorizedException())
-                return
-            }
+            sessionService.getHttpSession(request)
 
         val authSession: AuthSession
         try {
@@ -55,8 +52,8 @@ class SessionValidationFilter(
         } catch (e: EntityNotFoundException) {
             sessionService.delete(authSession.id)
             // 세션 쿠키 삭제
-            HttpUtil.getCookie(request, AuthConstants.SESSION_COOKIE_NAME)?.let { cookie ->
-                HttpUtil.deleteCookie(response, cookie)
+            HttpUtil.getCookie(request, AuthConstants.SESSION_COOKIE_NAME)?.let {
+                sessionService.unsetCookies(response)
             }
             HttpUtil.writeErrorResponse(response, HttpUnauthorizedException("User not found"))
             return

--- a/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
+++ b/src/api/src/main/kotlin/grantly/user/adapter/in/AuthController.kt
@@ -11,8 +11,10 @@ import grantly.user.adapter.out.dto.SignUpResponse
 import grantly.user.adapter.out.dto.UserResponse
 import grantly.user.application.port.`in`.CsrfTokenUseCase
 import grantly.user.application.port.`in`.LoginUseCase
+import grantly.user.application.port.`in`.LogoutUseCase
 import grantly.user.application.port.`in`.SignUpUseCase
 import grantly.user.application.port.`in`.dto.LoginParams
+import grantly.user.application.port.`in`.dto.LogoutParams
 import grantly.user.application.port.`in`.dto.SignUpParams
 import grantly.user.application.service.exceptions.DuplicateEmailException
 import grantly.user.application.service.exceptions.PasswordMismatchException
@@ -26,7 +28,6 @@ import jakarta.persistence.EntityNotFoundException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -43,10 +44,8 @@ class AuthController(
     private val signUpUseCase: SignUpUseCase,
     private val loginUseCase: LoginUseCase,
     private val csrfTokenUseCase: CsrfTokenUseCase,
+    private val logoutUseCase: LogoutUseCase,
 ) {
-    @Value("\${grantly.cookie.domain}")
-    private lateinit var cookieDomain: String
-
     @Operation(
         summary = "이메일을 이용한 회원가입",
         responses = [
@@ -145,6 +144,21 @@ class AuthController(
         response: HttpServletResponse,
     ): ResponseEntity<Void> {
         csrfTokenUseCase.issueCsrfToken(request, response)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(
+        summary = "로그아웃",
+        responses = [
+            ApiResponse(responseCode = "204", description = "로그아웃 성공"),
+        ],
+    )
+    @PostMapping("/logout")
+    fun logout(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): ResponseEntity<Void> {
+        logoutUseCase.logout(LogoutParams(request, response))
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/LogoutUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/LogoutUseCase.kt
@@ -1,0 +1,7 @@
+package grantly.user.application.port.`in`
+
+import grantly.user.application.port.`in`.dto.LogoutParams
+
+interface LogoutUseCase {
+    fun logout(params: LogoutParams)
+}

--- a/src/api/src/main/kotlin/grantly/user/application/port/in/dto/LogoutParams.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/port/in/dto/LogoutParams.kt
@@ -1,0 +1,9 @@
+package grantly.user.application.port.`in`.dto
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+data class LogoutParams(
+    val request: HttpServletRequest,
+    val response: HttpServletResponse,
+)

--- a/src/api/src/main/kotlin/grantly/user/application/service/CsrfTokenService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/CsrfTokenService.kt
@@ -30,6 +30,8 @@ class CsrfTokenService(
         sessionService.persistIfAbsent(request)
         // csrf token 쿠키 설정
         setCsrfTokenCookie(response, csrfToken)
+        // 세션/device id 쿠키 설정
+        sessionService.setCookies(request, response)
 
         return csrfToken
     }

--- a/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/SessionService.kt
@@ -118,8 +118,10 @@ class SessionService(
         request.setAttribute(AuthConstants.SESSION_ATTR, httpSession)
     }
 
-    fun getHttpSession(request: HttpServletRequest): CustomHttpSession =
-        request.getAttribute(AuthConstants.SESSION_ATTR) as CustomHttpSession
+    fun getHttpSession(request: HttpServletRequest): CustomHttpSession {
+        // TODO: HttpServletRequest 확장해서 getHttpSession() 메서드 추가
+        return request.getAttribute(AuthConstants.SESSION_ATTR) as CustomHttpSession
+    }
 
     fun persistIfAbsent(request: HttpServletRequest): AuthSession {
         val httpSession = getHttpSession(request)

--- a/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
@@ -1,6 +1,7 @@
 package grantly.user.application.service
 
 import grantly.common.annotations.UseCase
+import grantly.config.CustomHttpSession
 import grantly.user.application.port.`in`.EditProfileUseCase
 import grantly.user.application.port.`in`.FindUserQuery
 import grantly.user.application.port.`in`.LoginUseCase
@@ -70,19 +71,16 @@ class UserService(
         // 세션 값 갱신
         val (newSessionToken, expiresAt) = sessionService.generateSessionToken()
         authSession.replaceToken(newSessionToken, expiresAt)
-        // 유저와 연결
+        // 유저와 연결 및 저장
         authSession.connectUser(user.id)
-
         val updatedSession = sessionService.update(authSession)
 
-        // 세션 토큰을 쿠키에 설정
-        sessionService.setSessionToken(
-            params.response,
-            updatedSession.token,
-            updatedSession.expiresAt,
+        // 쿠키 설정
+        sessionService.setHttpSession(
+            params.request,
+            CustomHttpSession(updatedSession.token, updatedSession.expiresAt, updatedSession.deviceId),
         )
-        // 디바이스 ID를 쿠키에 설정
-        sessionService.setDeviceId(params.response, updatedSession.deviceId)
+        sessionService.setCookies(params.request, params.response)
         return updatedSession
     }
 

--- a/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
+++ b/src/api/src/main/kotlin/grantly/user/application/service/UserService.kt
@@ -1,9 +1,9 @@
 package grantly.user.application.service
 
 import grantly.common.annotations.UseCase
-import grantly.config.CustomHttpSession
 import grantly.common.constants.AuthConstants
 import grantly.common.utils.HttpUtil
+import grantly.config.CustomHttpSession
 import grantly.user.application.port.`in`.EditProfileUseCase
 import grantly.user.application.port.`in`.FindUserQuery
 import grantly.user.application.port.`in`.LoginUseCase

--- a/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
@@ -251,7 +251,7 @@ class AuthControllerTest(
             ).andExpect(status().isNoContent)
             .andExpect { result ->
                 val deletedCookie = result.response.getCookie(AuthConstants.SESSION_COOKIE_NAME)
-                assertThat(deletedCookie?.value).isNull()
+                assertThat(deletedCookie?.value).isEqualTo("")
                 assertThat(deletedCookie?.maxAge).isEqualTo(0)
             }
     }

--- a/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/user/adapter/in/AuthControllerTest.kt
@@ -237,6 +237,25 @@ class AuthControllerTest(
             .andExpect(cookie().exists(AuthConstants.CSRF_COOKIE_NAME))
     }
 
+    @Test
+    @DisplayName("로그아웃")
+    fun `should delete all cookies on logout`() {
+        // given
+        val authSession = createUserAuthSession(existingUser.id)
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/v1/auth/logout")
+                    .cookie(Cookie(AuthConstants.SESSION_COOKIE_NAME, authSession.token)),
+            ).andExpect(status().isNoContent)
+            .andExpect { result ->
+                val deletedCookie = result.response.getCookie(AuthConstants.SESSION_COOKIE_NAME)
+                assertThat(deletedCookie?.value).isNull()
+                assertThat(deletedCookie?.maxAge).isEqualTo(0)
+            }
+    }
+
     fun createTestUser(
         email: String,
         name: String,


### PR DESCRIPTION
## 변경내역
- SessionContext 미들웨어에서 session token 과 device id 에 대해 response cookie 를 설정해주는 로직을 제거하고 해당 필터의 역할을 request 객체에 CustomHttpSession 을 set 해주는 것으로만 제한했습니다.
- 이에 따라 로그인 api, csrf token 발급 api 에서 명시적으로 CustomHttpSession 을 꺼내 쿠키에 set 해주는 로직을 추가했습니다.
- 이와 같은 변경이 필요했던 이유는 로그아웃 시에도 동일한 필터를 타게 되는데 로그아웃 액션에서는 response cookie set 이 불필요함에도 무조건 쿠키가 미들웨어 단에서 설정되는 것이 부자연스럽다고 생각했기 때문입니다.
---
- 로그아웃 API

## 확인이 필요한 부분
-

## 배포 전 해야 할 일

- [ ]

### DB schema change

- [ ]

## 배포 후 해야 할 일

- [ ]

### DB schema change

- [ ]
