### PR TITLE
session 도메인 분리 및 auth_session 에서 member 제약 조건 제거

### DIFF
--- a/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
+++ b/src/api/src/main/kotlin/grantly/config/SecurityConfig.kt
@@ -4,7 +4,7 @@ import grantly.config.filter.CsrfValidationFilter
 import grantly.config.filter.SessionContext
 import grantly.config.filter.SessionValidationFilter
 import grantly.member.application.port.out.MemberRepository
-import grantly.member.application.service.SessionService
+import grantly.session.application.service.SessionService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile

--- a/src/api/src/main/kotlin/grantly/config/filter/SessionContext.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/SessionContext.kt
@@ -1,7 +1,7 @@
 package grantly.config.filter
 
 import grantly.config.CustomHttpSession
-import grantly.member.application.service.SessionService
+import grantly.session.application.service.SessionService
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
@@ -48,7 +48,7 @@ class SessionValidationFilter(
         val member: MemberDomain
         try {
             // 유저 정보 조회
-            member = memberRepository.getMember(authSession.memberId!!)
+            member = memberRepository.getMember(authSession.subjectId!!)
         } catch (e: EntityNotFoundException) {
             sessionService.delete(authSession.id)
             // 세션 쿠키 삭제

--- a/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
@@ -5,9 +5,9 @@ import grantly.common.exceptions.HttpUnauthorizedException
 import grantly.common.utils.HttpUtil
 import grantly.config.AuthenticatedMember
 import grantly.member.application.port.out.MemberRepository
-import grantly.member.application.service.SessionService
-import grantly.member.domain.AuthSessionDomain
 import grantly.member.domain.MemberDomain
+import grantly.session.application.service.SessionService
+import grantly.session.domain.AuthSessionDomain
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder

--- a/src/api/src/main/kotlin/grantly/member/adapter/in/MemberAuthController.kt
+++ b/src/api/src/main/kotlin/grantly/member/adapter/in/MemberAuthController.kt
@@ -11,7 +11,6 @@ import grantly.member.adapter.`in`.dto.SendEmailRequest
 import grantly.member.adapter.`in`.dto.SignUpRequest
 import grantly.member.adapter.out.dto.MemberResponse
 import grantly.member.adapter.out.dto.SignUpResponse
-import grantly.member.application.port.`in`.CsrfTokenUseCase
 import grantly.member.application.port.`in`.LoginUseCase
 import grantly.member.application.port.`in`.LogoutUseCase
 import grantly.member.application.port.`in`.PasswordResetUseCase
@@ -22,6 +21,7 @@ import grantly.member.application.port.`in`.dto.SignUpParams
 import grantly.member.application.service.exceptions.DuplicateEmailException
 import grantly.member.application.service.exceptions.PasswordMismatchException
 import grantly.member.domain.MemberDomain
+import grantly.session.application.port.`in`.CsrfTokenUseCase
 import grantly.token.application.service.exceptions.InvalidTokenException
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -44,7 +44,7 @@ import org.springframework.web.bind.annotation.RestController
 @ResponseBody
 @RequestMapping("/v1/auth")
 @Tag(name = "인증", description = "인증 관련 API")
-class AuthController(
+class MemberAuthController(
     private val signUpUseCase: SignUpUseCase,
     private val loginUseCase: LoginUseCase,
     private val csrfTokenUseCase: CsrfTokenUseCase,

--- a/src/api/src/main/kotlin/grantly/member/application/port/in/LoginUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/member/application/port/in/LoginUseCase.kt
@@ -1,7 +1,7 @@
 package grantly.member.application.port.`in`
 
 import grantly.member.application.port.`in`.dto.LoginParams
-import grantly.member.domain.AuthSessionDomain
+import grantly.session.domain.AuthSessionDomain
 
 interface LoginUseCase {
     fun login(params: LoginParams): AuthSessionDomain

--- a/src/api/src/main/kotlin/grantly/member/application/service/MemberService.kt
+++ b/src/api/src/main/kotlin/grantly/member/application/service/MemberService.kt
@@ -19,8 +19,9 @@ import grantly.member.application.port.`in`.dto.SignUpParams
 import grantly.member.application.port.out.MemberRepository
 import grantly.member.application.service.exceptions.DuplicateEmailException
 import grantly.member.application.service.exceptions.PasswordMismatchException
-import grantly.member.domain.AuthSessionDomain
 import grantly.member.domain.MemberDomain
+import grantly.session.application.service.SessionService
+import grantly.session.domain.AuthSessionDomain
 import grantly.token.adapter.out.dto.MemberIdTokenPayload
 import grantly.token.application.service.TokenService
 import grantly.token.application.service.exceptions.InvalidTokenException

--- a/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionJpaEntity.kt
@@ -1,9 +1,10 @@
-package grantly.member.adapter.out
+package grantly.session.adapter.out
 
 import grantly.common.entity.BaseEntity
 import grantly.common.entity.entityEquals
 import grantly.common.entity.entityHashCode
 import grantly.common.entity.entityToString
+import grantly.member.adapter.out.MemberJpaEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType

--- a/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionJpaEntity.kt
@@ -4,15 +4,11 @@ import grantly.common.entity.BaseEntity
 import grantly.common.entity.entityEquals
 import grantly.common.entity.entityHashCode
 import grantly.common.entity.entityToString
-import grantly.member.adapter.out.MemberJpaEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import java.time.OffsetDateTime
 
@@ -33,11 +29,10 @@ class AuthSessionJpaEntity(
     val ip: String? = null,
     @Column(nullable = false)
     val expiresAt: OffsetDateTime,
-    @Column(name = "member_id", nullable = true)
-    val memberId: Long? = null,
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = true, referencedColumnName = "id", updatable = false, insertable = false)
-    val member: MemberJpaEntity? = null,
+    @Column(nullable = true)
+    val subjectId: Long? = null,
+    @Column(nullable = true)
+    val subjectType: Int? = null,
 ) : BaseEntity() {
     override fun toString() = entityToString(*toStringProperties)
 
@@ -47,6 +42,11 @@ class AuthSessionJpaEntity(
 
     companion object {
         val toStringProperties =
-            arrayOf(AuthSessionJpaEntity::id, AuthSessionJpaEntity::memberId, AuthSessionJpaEntity::token)
+            arrayOf(
+                AuthSessionJpaEntity::id,
+                AuthSessionJpaEntity::subjectId,
+                AuthSessionJpaEntity::subjectType,
+                AuthSessionJpaEntity::token,
+            )
     }
 }

--- a/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionJpaRepository.kt
+++ b/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionJpaRepository.kt
@@ -1,4 +1,4 @@
-package grantly.member.adapter.out
+package grantly.session.adapter.out
 
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional

--- a/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionJpaRepository.kt
+++ b/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionJpaRepository.kt
@@ -6,5 +6,8 @@ import java.util.Optional
 interface AuthSessionJpaRepository : JpaRepository<AuthSessionJpaEntity, Long> {
     fun findByToken(token: String): Optional<AuthSessionJpaEntity>
 
-    fun findByMemberId(userId: Long): Optional<AuthSessionJpaEntity>
+    fun findBySubjectIdAndSubjectType(
+        subjectId: Long,
+        subjectType: Int,
+    ): Optional<AuthSessionJpaEntity>
 }

--- a/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionMapper.kt
+++ b/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionMapper.kt
@@ -1,7 +1,9 @@
 package grantly.session.adapter.out
 
+import aws.smithy.kotlin.runtime.util.type
 import grantly.common.entity.IsMapper
 import grantly.session.domain.AuthSessionDomain
+import grantly.session.domain.SubjectType
 import org.springframework.stereotype.Component
 
 @Component
@@ -9,7 +11,8 @@ class AuthSessionMapper : IsMapper<AuthSessionJpaEntity, AuthSessionDomain> {
     override fun toDomain(entity: AuthSessionJpaEntity): AuthSessionDomain =
         AuthSessionDomain(
             id = entity.id ?: 0L,
-            memberId = entity.memberId,
+            subjectId = entity.subjectId,
+            subjectType = entity.subjectType?.let { SubjectType.from(it) },
             deviceId = entity.deviceId,
             ip = entity.ip,
             token = entity.token,
@@ -22,7 +25,8 @@ class AuthSessionMapper : IsMapper<AuthSessionJpaEntity, AuthSessionDomain> {
     override fun toEntity(domain: AuthSessionDomain): AuthSessionJpaEntity =
         AuthSessionJpaEntity(
             id = if (domain.id == 0L) null else domain.id,
-            memberId = domain.memberId,
+            subjectId = domain.subjectId,
+            subjectType = domain.subjectType?.type,
             token = domain.token,
             deviceId = domain.deviceId,
             ip = domain.ip,

--- a/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionMapper.kt
+++ b/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionMapper.kt
@@ -1,7 +1,7 @@
-package grantly.member.adapter.out
+package grantly.session.adapter.out
 
 import grantly.common.entity.IsMapper
-import grantly.member.domain.AuthSessionDomain
+import grantly.session.domain.AuthSessionDomain
 import org.springframework.stereotype.Component
 
 @Component

--- a/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionPersistenceAdapter.kt
+++ b/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionPersistenceAdapter.kt
@@ -1,8 +1,8 @@
-package grantly.member.adapter.out
+package grantly.session.adapter.out
 
 import grantly.common.annotations.PersistenceAdapter
-import grantly.member.application.port.out.AuthSessionRepository
-import grantly.member.domain.AuthSessionDomain
+import grantly.session.application.port.out.AuthSessionRepository
+import grantly.session.domain.AuthSessionDomain
 import jakarta.persistence.EntityNotFoundException
 
 @PersistenceAdapter

--- a/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionPersistenceAdapter.kt
+++ b/src/api/src/main/kotlin/grantly/session/adapter/out/AuthSessionPersistenceAdapter.kt
@@ -3,6 +3,7 @@ package grantly.session.adapter.out
 import grantly.common.annotations.PersistenceAdapter
 import grantly.session.application.port.out.AuthSessionRepository
 import grantly.session.domain.AuthSessionDomain
+import grantly.session.domain.SubjectType
 import jakarta.persistence.EntityNotFoundException
 
 @PersistenceAdapter
@@ -16,7 +17,7 @@ class AuthSessionPersistenceAdapter(
     }
 
     override fun getSessionByMemberId(memberId: Long): AuthSessionDomain {
-        val sessionEntity = authSessionJpaRepository.findByMemberId(memberId)
+        val sessionEntity = authSessionJpaRepository.findBySubjectIdAndSubjectType(memberId, SubjectType.MEMBER.type)
         if (sessionEntity.isEmpty) {
             throw EntityNotFoundException("AuthSession not found")
         }

--- a/src/api/src/main/kotlin/grantly/session/application/port/in/CsrfTokenUseCase.kt
+++ b/src/api/src/main/kotlin/grantly/session/application/port/in/CsrfTokenUseCase.kt
@@ -1,4 +1,4 @@
-package grantly.member.application.port.`in`
+package grantly.session.application.port.`in`
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/src/api/src/main/kotlin/grantly/session/application/port/out/AuthSessionRepository.kt
+++ b/src/api/src/main/kotlin/grantly/session/application/port/out/AuthSessionRepository.kt
@@ -1,6 +1,6 @@
-package grantly.member.application.port.out
+package grantly.session.application.port.out
 
-import grantly.member.domain.AuthSessionDomain
+import grantly.session.domain.AuthSessionDomain
 
 interface AuthSessionRepository {
     fun updateSession(session: AuthSessionDomain): AuthSessionDomain

--- a/src/api/src/main/kotlin/grantly/session/application/service/CsrfTokenService.kt
+++ b/src/api/src/main/kotlin/grantly/session/application/service/CsrfTokenService.kt
@@ -1,9 +1,9 @@
-package grantly.member.application.service
+package grantly.session.application.service
 
 import grantly.common.annotations.UseCase
 import grantly.common.constants.AuthConstants
 import grantly.common.utils.HttpUtil
-import grantly.member.application.port.`in`.CsrfTokenUseCase
+import grantly.session.application.port.`in`.CsrfTokenUseCase
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value

--- a/src/api/src/main/kotlin/grantly/session/application/service/SessionService.kt
+++ b/src/api/src/main/kotlin/grantly/session/application/service/SessionService.kt
@@ -1,10 +1,10 @@
-package grantly.member.application.service
+package grantly.session.application.service
 
 import grantly.common.constants.AuthConstants
 import grantly.common.utils.HttpUtil
 import grantly.config.CustomHttpSession
-import grantly.member.application.port.out.AuthSessionRepository
-import grantly.member.domain.AuthSessionDomain
+import grantly.session.application.port.out.AuthSessionRepository
+import grantly.session.domain.AuthSessionDomain
 import jakarta.persistence.EntityNotFoundException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/src/api/src/main/kotlin/grantly/session/application/service/exceptions/TokenGenerationException.kt
+++ b/src/api/src/main/kotlin/grantly/session/application/service/exceptions/TokenGenerationException.kt
@@ -1,3 +1,3 @@
-package grantly.member.application.service.exceptions
+package grantly.session.application.service.exceptions
 
 class TokenGenerationException : RuntimeException("Failed to generate token")

--- a/src/api/src/main/kotlin/grantly/session/domain/AuthSessionDomain.kt
+++ b/src/api/src/main/kotlin/grantly/session/domain/AuthSessionDomain.kt
@@ -6,7 +6,8 @@ import java.time.OffsetDateTime
 @Schema(description = "세션 도메인 모델")
 data class AuthSessionDomain(
     val id: Long = 0L,
-    var memberId: Long? = null,
+    var subjectId: Long? = null,
+    var subjectType: SubjectType? = null,
     var token: String,
     var deviceId: String,
     var ip: String? = null,
@@ -17,7 +18,7 @@ data class AuthSessionDomain(
 ) {
     fun isValid(): Boolean = expiresAt.isAfter(OffsetDateTime.now())
 
-    fun isAnonymous(): Boolean = memberId == null
+    fun isAnonymous(): Boolean = subjectId == null
 
     fun updateMeta(
         ip: String?,
@@ -30,7 +31,7 @@ data class AuthSessionDomain(
     }
 
     fun connectMember(userId: Long) {
-        this.memberId = userId
+        this.subjectId = userId
     }
 
     fun replaceToken(

--- a/src/api/src/main/kotlin/grantly/session/domain/AuthSessionDomain.kt
+++ b/src/api/src/main/kotlin/grantly/session/domain/AuthSessionDomain.kt
@@ -1,4 +1,4 @@
-package grantly.member.domain
+package grantly.session.domain
 
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.OffsetDateTime

--- a/src/api/src/main/kotlin/grantly/session/domain/SubjectType.kt
+++ b/src/api/src/main/kotlin/grantly/session/domain/SubjectType.kt
@@ -1,0 +1,15 @@
+package grantly.session.domain
+
+enum class SubjectType(
+    val type: Int,
+) {
+    MEMBER(0),
+    USER(1),
+    ;
+
+    companion object {
+        fun from(type: Int): SubjectType =
+            SubjectType.entries.find { it.type == type }
+                ?: throw IllegalArgumentException("Unknown SubjectType: $type")
+    }
+}

--- a/src/api/src/main/resources/migrations/V9__auth_session_subject_id.sql
+++ b/src/api/src/main/resources/migrations/V9__auth_session_subject_id.sql
@@ -1,0 +1,11 @@
+ALTER TABLE auth_session
+    DROP FOREIGN KEY FK_AUTH_SESSION_ON_MEMBER;
+
+ALTER TABLE auth_session
+    DROP COLUMN member_id;
+
+ALTER TABLE auth_session
+    ADD COLUMN subject_id BIGINT NULL;
+
+ALTER TABLE auth_session
+    ADD COLUMN subject_type SMALLINT NULL;

--- a/src/api/src/test/kotlin/grantly/app/adapter/in/AppClientControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/app/adapter/in/AppClientControllerTest.kt
@@ -21,6 +21,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
@@ -36,6 +37,7 @@ import java.util.UUID
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Transactional
 class AppClientControllerTest(
     @Autowired

--- a/src/api/src/test/kotlin/grantly/app/adapter/in/AppControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/app/adapter/in/AppControllerTest.kt
@@ -12,7 +12,6 @@ import grantly.config.WithTestSessionMember
 import grantly.member.application.port.out.MemberRepository
 import grantly.member.domain.MemberDomain
 import jakarta.persistence.EntityNotFoundException
-import jakarta.transaction.Transactional
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -25,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
@@ -34,14 +34,17 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
 import java.time.OffsetDateTime
 import java.util.UUID
 
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@Transactional
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@WithTestSessionMember
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Transactional
 class AppControllerTest(
     @Autowired
     private val mockMvc: MockMvc,
@@ -56,7 +59,6 @@ class AppControllerTest(
 ) {
     @Test
     @DisplayName("활성화된 애플리케이션만 목록에 포함하여 조회")
-    @WithTestSessionMember
     fun `should exclude deactivated apps on list action`() {
         // given
         val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
@@ -76,7 +78,6 @@ class AppControllerTest(
 
     @Test
     @DisplayName("앱 생성")
-    @WithTestSessionMember
     fun createApp() {
         // given
         val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
@@ -107,7 +108,6 @@ class AppControllerTest(
 
     @Test
     @DisplayName("앱 삭제")
-    @WithTestSessionMember
     fun deleteApp() {
         // given
         val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
@@ -127,7 +127,6 @@ class AppControllerTest(
 
     @Test
     @DisplayName("앱의 소유자만 삭제 가능")
-    @WithTestSessionMember
     fun `should only allow app owner to delete`() {
         // given
         val newMember =
@@ -150,7 +149,6 @@ class AppControllerTest(
 
     @Test
     @DisplayName("활성화 상태의 앱이 1개뿐일 때 삭제 불가")
-    @WithTestSessionMember
     fun `cannot delete the only active app`() {
         // given
         val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
@@ -166,7 +164,6 @@ class AppControllerTest(
 
     @Test
     @DisplayName("앱 메타 데이터 수정")
-    @WithTestSessionMember
     fun updateApp() {
         // given
         val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
@@ -196,7 +193,6 @@ class AppControllerTest(
 
     @Test
     @DisplayName("이미지 업로드 시 이미지 경로가 올바르게 저장된다.")
-    @WithTestSessionMember
     fun uploadApplicationImage() {
         // given
         val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
@@ -225,7 +221,6 @@ class AppControllerTest(
 
     @Test
     @DisplayName("이미지 초기화 시 이미지 경로가 null 로 저장되고 파일이 제거된다.")
-    @WithTestSessionMember
     fun deleteApplicationImage() {
         // given
         val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember

--- a/src/api/src/test/kotlin/grantly/config/WithSessionSecurityContextFactory.kt
+++ b/src/api/src/test/kotlin/grantly/config/WithSessionSecurityContextFactory.kt
@@ -1,9 +1,9 @@
 package grantly.config
 
-import grantly.member.application.port.out.AuthSessionRepository
 import grantly.member.application.port.out.MemberRepository
-import grantly.member.domain.AuthSessionDomain
 import grantly.member.domain.MemberDomain
+import grantly.session.application.port.out.AuthSessionRepository
+import grantly.session.domain.AuthSessionDomain
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestComponent

--- a/src/api/src/test/kotlin/grantly/config/WithSessionSecurityContextFactory.kt
+++ b/src/api/src/test/kotlin/grantly/config/WithSessionSecurityContextFactory.kt
@@ -36,7 +36,7 @@ class WithSessionSecurityContextFactory(
                 // 세션이 존재하지 않으면 새로 생성
                 val newAuthSession =
                     AuthSessionDomain(
-                        memberId = member.id,
+                        subjectId = member.id,
                         token = "testToken",
                         expiresAt = OffsetDateTime.now().plusDays(1),
                         deviceId = "testDeviceId",
@@ -81,7 +81,7 @@ class WithSessionSecurityContextFactory(
         val createdMember = memberRepository.createMember(member)
         val authSession =
             AuthSessionDomain(
-                memberId = createdMember.id,
+                subjectId = createdMember.id,
                 token = "testToken",
                 expiresAt = OffsetDateTime.now().plusDays(1),
                 deviceId = "testDeviceId",

--- a/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
@@ -28,6 +28,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -49,6 +50,7 @@ import java.util.UUID
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class AuthControllerTest(
     @Autowired
     private val memberRepository: MemberRepository,
@@ -83,7 +85,7 @@ class AuthControllerTest(
     private lateinit var existingMember: MemberDomain
 
     @BeforeAll
-    fun setUp() {
+    fun createTestMember() {
         existingMember = createTestMember("test@email.com", "test", "test123!")
     }
 

--- a/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
@@ -5,10 +5,10 @@ import grantly.app.application.port.out.AppRepository
 import grantly.common.constants.AuthConstants
 import grantly.member.adapter.`in`.dto.LoginRequest
 import grantly.member.adapter.`in`.dto.SignUpRequest
-import grantly.member.application.port.out.AuthSessionRepository
 import grantly.member.application.port.out.MemberRepository
-import grantly.member.domain.AuthSessionDomain
 import grantly.member.domain.MemberDomain
+import grantly.session.application.port.out.AuthSessionRepository
+import grantly.session.domain.AuthSessionDomain
 import grantly.token.adapter.out.enums.TokenType
 import grantly.token.application.port.out.TokenRepository
 import grantly.token.domain.TokenDomain

--- a/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
@@ -9,6 +9,7 @@ import grantly.member.application.port.out.MemberRepository
 import grantly.member.domain.MemberDomain
 import grantly.session.application.port.out.AuthSessionRepository
 import grantly.session.domain.AuthSessionDomain
+import grantly.session.domain.SubjectType
 import grantly.token.adapter.out.enums.TokenType
 import grantly.token.application.port.out.TokenRepository
 import grantly.token.domain.TokenDomain
@@ -25,10 +26,11 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.core.env.Environment
 import org.springframework.http.MediaType
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -38,6 +40,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -58,18 +61,23 @@ class AuthControllerTest(
     @Autowired
     private val objectMapper: ObjectMapper,
     @Autowired
-    private val env: Environment,
-    @Autowired
     private val passwordEncoder: BCryptPasswordEncoder,
     @Autowired
     private val appRepository: AppRepository,
 ) {
     companion object {
         @Container
-        val redisContainer =
-            GenericContainer("redis:7.0").apply {
-                withExposedPorts(6379)
-            }
+        val redis =
+            GenericContainer(DockerImageName.parse("redis:7"))
+                .withExposedPorts(6379)
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun overrideRedisProperties(registry: DynamicPropertyRegistry) {
+            redis.start()
+            registry.add("spring.data.redis.host") { redis.host }
+            registry.add("spring.data.redis.port") { redis.getMappedPort(6379) }
+        }
     }
 
     private lateinit var existingMember: MemberDomain
@@ -362,6 +370,7 @@ class AuthControllerTest(
     fun createAnonymousAuthSession(): AuthSessionDomain {
         val session =
             AuthSessionDomain(
+                subjectType = SubjectType.MEMBER,
                 token = UUID.randomUUID().toString(),
                 deviceId = UUID.randomUUID().toString(),
                 expiresAt = OffsetDateTime.now().plusSeconds(3600),
@@ -376,6 +385,7 @@ class AuthControllerTest(
                 deviceId = UUID.randomUUID().toString(),
                 expiresAt = OffsetDateTime.now().plusSeconds(3600),
                 subjectId = memberId,
+                subjectType = SubjectType.MEMBER,
             )
         return authSessionRepository.createSession(session)
     }

--- a/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
@@ -375,7 +375,7 @@ class AuthControllerTest(
                 token = UUID.randomUUID().toString(),
                 deviceId = UUID.randomUUID().toString(),
                 expiresAt = OffsetDateTime.now().plusSeconds(3600),
-                memberId = memberId,
+                subjectId = memberId,
             )
         return authSessionRepository.createSession(session)
     }

--- a/src/api/src/test/kotlin/grantly/member/adapter/in/MemberControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/member/adapter/in/MemberControllerTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -20,6 +21,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@WithTestSessionMember(email = "test@email.com", name = "testUser")
 class MemberControllerTest(
     @Autowired
     private val mockMvc: MockMvc,
@@ -29,7 +32,6 @@ class MemberControllerTest(
 
     @Test
     @DisplayName("요청 사용자 정보 조회")
-    @WithTestSessionMember(email = "test@email.com", name = "test")
     fun `should get request member data`() {
         // given
         // when & then
@@ -39,6 +41,6 @@ class MemberControllerTest(
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.email").value("test@email.com"))
-            .andExpect(jsonPath("$.name").value("test"))
+            .andExpect(jsonPath("$.name").value("testUser"))
     }
 }

--- a/src/api/src/test/resources/application-test.yml
+++ b/src/api/src/test/resources/application-test.yml
@@ -12,10 +12,9 @@ spring:
     password:
     driver-class-name: org.h2.Driver
     hikari:
-      jdbc-url: jdbc:h2:mem:test;NON_KEYWORDS=user;DB_CLOSE_DELAY=-1;MODE=MYSQL;SCHEMA=PUBLIC;DATABASE_TO_LOWER=TRUE
+      jdbc-url: jdbc:h2:mem:test;NON_KEYWORDS=user;MODE=MYSQL;SCHEMA=PUBLIC;DATABASE_TO_LOWER=TRUE
   sql:
     init:
-      mode: always
       schema-locations: classpath:schema-h2.sql
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect

--- a/src/api/src/test/resources/application-test.yml
+++ b/src/api/src/test/resources/application-test.yml
@@ -2,6 +2,11 @@ spring:
   config:
     activate:
       on-profile: test
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 6000
   datasource:
     username: sa
     password:

--- a/src/api/src/test/resources/schema-h2.sql
+++ b/src/api/src/test/resources/schema-h2.sql
@@ -1,69 +1,70 @@
 CREATE TABLE IF NOT EXISTS member
 (
     id            BIGINT auto_increment NOT NULL,
-    created_at    DATETIME NOT NULL,
-    modified_at   DATETIME NOT NULL,
-    email         VARCHAR(100) NOT NULL,
-    password      VARCHAR(255) NULL,
-    name          VARCHAR(255) NOT NULL,
-    last_login_at DATETIME NULL,
+    created_at    DATETIME              NOT NULL,
+    modified_at   DATETIME              NOT NULL,
+    email         VARCHAR(100)          NOT NULL,
+    password      VARCHAR(255)          NULL,
+    name          VARCHAR(255)          NOT NULL,
+    last_login_at DATETIME              NULL,
     CONSTRAINT pk_member PRIMARY KEY (id)
-    );
+);
 
 ALTER TABLE member
-    ADD CONSTRAINT uc_member_email UNIQUE (email);
+    ADD CONSTRAINT IF NOT EXISTS uc_member_email UNIQUE (email);
 
 CREATE TABLE IF NOT EXISTS auth_session
 (
     id           BIGINT auto_increment NOT NULL,
-    created_at   DATETIME NOT NULL,
-    modified_at  DATETIME NOT NULL,
-    token        VARCHAR(50) NOT NULL,
-    device_id    VARCHAR(50) NOT NULL,
-    user_agent   VARCHAR(255) NULL,
-    ip           VARCHAR(45) NULL,
-    expires_at   DATETIME NOT NULL,
-    subject_id   BIGINT NULL,
-    subject_type SMALLINT NULL,
+    created_at   DATETIME              NOT NULL,
+    modified_at  DATETIME              NOT NULL,
+    token        VARCHAR(50)           NOT NULL,
+    device_id    VARCHAR(50)           NOT NULL,
+    user_agent   VARCHAR(255)          NULL,
+    ip           VARCHAR(45)           NULL,
+    expires_at   DATETIME              NOT NULL,
+    subject_id   BIGINT                NULL,
+    subject_type SMALLINT              NULL,
     CONSTRAINT pk_auth_session PRIMARY KEY (id)
-    );
+);
 
 ALTER TABLE auth_session
-    ADD CONSTRAINT uc_auth_session_token UNIQUE (token);
+    ADD CONSTRAINT IF NOT EXISTS uc_auth_session_token UNIQUE (token);
 
 CREATE TABLE IF NOT EXISTS token
 (
     id          BIGINT auto_increment NOT NULL,
-    created_at  DATETIME NOT NULL,
-    modified_at DATETIME NOT NULL,
-    token       VARCHAR(50) NOT NULL,
-    expires_at  DATETIME NOT NULL,
-    type        INT NOT NULL,
-    payload     TEXT NOT NULL,
-    is_active   BOOLEAN NOT NULL DEFAULT true,
+    created_at  DATETIME              NOT NULL,
+    modified_at DATETIME              NOT NULL,
+    token       VARCHAR(50)           NOT NULL,
+    expires_at  DATETIME              NOT NULL,
+    type        INT                   NOT NULL,
+    payload     TEXT                  NOT NULL,
+    is_active   BOOLEAN               NOT NULL DEFAULT true,
     CONSTRAINT pk_token PRIMARY KEY (id)
-    );
+);
 
 ALTER TABLE token
-    ADD CONSTRAINT uc_token_token UNIQUE (token);
+    ADD CONSTRAINT IF NOT EXISTS uc_token_token UNIQUE (token);
 
 CREATE TABLE IF NOT EXISTS application
 (
     id            BIGINT auto_increment NOT NULL,
-    created_at    DATETIME NOT NULL,
-    modified_at   DATETIME NOT NULL,
-    slug          VARCHAR(50) NOT NULL,
-    name          VARCHAR(50) NOT NULL,
-    image_url     VARCHAR(255) NULL,
-    `description` VARCHAR(512) NULL,
-    owner_id      BIGINT NOT NULL,
-    is_active     BOOLEAN NOT NULL DEFAULT true,
+    created_at    DATETIME              NOT NULL,
+    modified_at   DATETIME              NOT NULL,
+    slug          VARCHAR(50)           NOT NULL,
+    name          VARCHAR(50)           NOT NULL,
+    image_url     VARCHAR(255)          NULL,
+    `description` VARCHAR(512)          NULL,
+    owner_id      BIGINT                NOT NULL,
+    is_active     BOOLEAN               NOT NULL DEFAULT true,
     CONSTRAINT pk_service PRIMARY KEY (id)
-    );
+);
 
 ALTER TABLE application
-    ADD CONSTRAINT uc_application_slug UNIQUE (slug);
+    ADD CONSTRAINT IF NOT EXISTS uc_application_slug UNIQUE (slug);
 
 ALTER TABLE application
-    ADD CONSTRAINT fk_application_on_owner FOREIGN KEY (owner_id) REFERENCES
-        member (id);
+    DROP CONSTRAINT IF EXISTS fk_application_on_owner;
+ALTER TABLE application
+    ADD CONSTRAINT fk_application_on_owner FOREIGN KEY (owner_id) REFERENCES member (id);

--- a/src/api/src/test/resources/schema-h2.sql
+++ b/src/api/src/test/resources/schema-h2.sql
@@ -1,70 +1,69 @@
 CREATE TABLE IF NOT EXISTS member
 (
-    id            BIGINT AUTO_INCREMENT NOT NULL,
-    created_at    datetime              NOT NULL,
-    modified_at   datetime              NOT NULL,
-    email         VARCHAR(100)          NOT NULL,
-    password      VARCHAR(255)          NULL,
-    name          VARCHAR(255)          NOT NULL,
-    last_login_at datetime              NULL,
+    id            BIGINT auto_increment NOT NULL,
+    created_at    DATETIME NOT NULL,
+    modified_at   DATETIME NOT NULL,
+    email         VARCHAR(100) NOT NULL,
+    password      VARCHAR(255) NULL,
+    name          VARCHAR(255) NOT NULL,
+    last_login_at DATETIME NULL,
     CONSTRAINT pk_member PRIMARY KEY (id)
-);
+    );
 
 ALTER TABLE member
     ADD CONSTRAINT uc_member_email UNIQUE (email);
 
 CREATE TABLE IF NOT EXISTS auth_session
 (
-    id          BIGINT AUTO_INCREMENT NOT NULL,
-    created_at  datetime              NOT NULL,
-    modified_at datetime              NOT NULL,
-    token       VARCHAR(50)           NOT NULL,
-    device_id   VARCHAR(50)           NOT NULL,
-    user_agent  VARCHAR(255)          NULL,
-    ip          VARCHAR(45)           NULL,
-    expires_at  datetime              NOT NULL,
-    member_id   BIGINT                NULL,
+    id           BIGINT auto_increment NOT NULL,
+    created_at   DATETIME NOT NULL,
+    modified_at  DATETIME NOT NULL,
+    token        VARCHAR(50) NOT NULL,
+    device_id    VARCHAR(50) NOT NULL,
+    user_agent   VARCHAR(255) NULL,
+    ip           VARCHAR(45) NULL,
+    expires_at   DATETIME NOT NULL,
+    subject_id   BIGINT NULL,
+    subject_type SMALLINT NULL,
     CONSTRAINT pk_auth_session PRIMARY KEY (id)
-);
+    );
 
 ALTER TABLE auth_session
     ADD CONSTRAINT uc_auth_session_token UNIQUE (token);
 
-ALTER TABLE auth_session
-    ADD CONSTRAINT FK_AUTH_SESSION_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (id);
-
 CREATE TABLE IF NOT EXISTS token
 (
-    id          BIGINT AUTO_INCREMENT NOT NULL,
-    created_at  datetime              NOT NULL,
-    modified_at datetime              NOT NULL,
-    token       VARCHAR(50)           NOT NULL,
-    expires_at  datetime              NOT NULL,
-    type        INT                   NOT NULL,
-    payload     TEXT                  NOT NULL,
-    is_active   BOOLEAN               NOT NULL DEFAULT TRUE,
+    id          BIGINT auto_increment NOT NULL,
+    created_at  DATETIME NOT NULL,
+    modified_at DATETIME NOT NULL,
+    token       VARCHAR(50) NOT NULL,
+    expires_at  DATETIME NOT NULL,
+    type        INT NOT NULL,
+    payload     TEXT NOT NULL,
+    is_active   BOOLEAN NOT NULL DEFAULT true,
     CONSTRAINT pk_token PRIMARY KEY (id)
-);
+    );
 
 ALTER TABLE token
     ADD CONSTRAINT uc_token_token UNIQUE (token);
 
 CREATE TABLE IF NOT EXISTS application
 (
-    id            BIGINT AUTO_INCREMENT NOT NULL,
-    created_at    datetime              NOT NULL,
-    modified_at   datetime              NOT NULL,
-    slug          VARCHAR(50)           NOT NULL,
-    name          VARCHAR(50)           NOT NULL,
-    image_url     VARCHAR(255)          NULL,
-    `description` VARCHAR(512)          NULL,
-    owner_id      BIGINT                NOT NULL,
-    is_active     BOOLEAN               NOT NULL DEFAULT TRUE,
+    id            BIGINT auto_increment NOT NULL,
+    created_at    DATETIME NOT NULL,
+    modified_at   DATETIME NOT NULL,
+    slug          VARCHAR(50) NOT NULL,
+    name          VARCHAR(50) NOT NULL,
+    image_url     VARCHAR(255) NULL,
+    `description` VARCHAR(512) NULL,
+    owner_id      BIGINT NOT NULL,
+    is_active     BOOLEAN NOT NULL DEFAULT true,
     CONSTRAINT pk_service PRIMARY KEY (id)
-);
+    );
 
 ALTER TABLE application
-    ADD CONSTRAINT UC_APPLICATION_SLUG UNIQUE (slug);
+    ADD CONSTRAINT uc_application_slug UNIQUE (slug);
 
 ALTER TABLE application
-    ADD CONSTRAINT FK_APPLICATION_ON_OWNER FOREIGN KEY (owner_id) REFERENCES member (id);
+    ADD CONSTRAINT fk_application_on_owner FOREIGN KEY (owner_id) REFERENCES
+        member (id);


### PR DESCRIPTION
## 변경내역
- diff 가 크긴 하지만 1) member 하위에 있던 session 도메인 분리, 2) auth_session 테이블에서 제약조건 제거 이렇게 두가지 작업입니다.
- resolves #121

## 확인이 필요한 부분
-

## 배포 전 해야 할 일

- [ ]

### DB schema change

- [ ] V9__auth_session_subject_id.sql
```sql
ALTER TABLE auth_session
    DROP FOREIGN KEY FK_AUTH_SESSION_ON_MEMBER;

ALTER TABLE auth_session
    DROP COLUMN member_id;

ALTER TABLE auth_session
    ADD COLUMN subject_id BIGINT NULL;

ALTER TABLE auth_session
    ADD COLUMN subject_type SMALLINT NULL;
```

## 배포 후 해야 할 일

- [ ]

### DB schema change

- [ ]
