### PR TITLE
admin path prefix 추가 및 UserDetails 구현체에 role 추가

### DIFF
--- a/src/api/src/main/kotlin/grantly/app/adapter/in/AppClientController.kt
+++ b/src/api/src/main/kotlin/grantly/app/adapter/in/AppClientController.kt
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @ResponseBody
-@RequestMapping("/v1/apps/{appSlug}/clients")
+@RequestMapping("/admin/v1/apps/{appSlug}/clients")
 @Tag(name = "OAuth 클라이언트", description = "멤버가 등록한 앱의 OAuth 클라이언트 관련 API")
 class AppClientController(
     private val createAppClientUseCase: CreateAppClientUseCase,

--- a/src/api/src/main/kotlin/grantly/app/adapter/in/AppClientController.kt
+++ b/src/api/src/main/kotlin/grantly/app/adapter/in/AppClientController.kt
@@ -1,6 +1,5 @@
 package grantly.app.adapter.`in`
 
-import grantly.app.adapter.`in`.AppGuard
 import grantly.app.adapter.`in`.dto.AppClientResponse
 import grantly.app.adapter.`in`.dto.CreateAppClientRequest
 import grantly.app.adapter.`in`.dto.UpdateAppClientRequest
@@ -13,7 +12,7 @@ import grantly.app.application.port.`in`.dto.DeleteAppClientParams
 import grantly.app.application.port.`in`.dto.FindAppClientParams
 import grantly.app.application.port.`in`.dto.UpdateAppClientParams
 import grantly.common.exceptions.HttpNotFoundException
-import grantly.config.AuthenticatedMember
+import grantly.config.AuthenticationEntity
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -64,7 +63,7 @@ class AppClientController(
     @PostMapping
     fun createAppClient(
         @PathVariable appSlug: String,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
         @Valid @RequestBody request: CreateAppClientRequest,
     ): ResponseEntity<AppClientResponse> {
         val app = appGuard.checkAccess(appSlug, requestMember.getId())
@@ -103,7 +102,7 @@ class AppClientController(
     fun updateAppClient(
         @PathVariable appSlug: String,
         @PathVariable clientId: String,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
         @Valid @RequestBody request: UpdateAppClientRequest,
     ): ResponseEntity<AppClientResponse> {
         val app = appGuard.checkAccess(appSlug, requestMember.getId())
@@ -141,7 +140,7 @@ class AppClientController(
     fun deleteAppClient(
         @PathVariable appSlug: String,
         @PathVariable clientId: String,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<Unit> {
         val app = appGuard.checkAccess(appSlug, requestMember.getId())
 
@@ -179,7 +178,7 @@ class AppClientController(
     fun getAppClient(
         @PathVariable appSlug: String,
         @PathVariable clientId: String,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<AppClientResponse> {
         val app = appGuard.checkAccess(appSlug, requestMember.getId())
 
@@ -217,7 +216,7 @@ class AppClientController(
     @GetMapping
     fun getAppClients(
         @PathVariable appSlug: String,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<List<AppClientResponse>> {
         val app = appGuard.checkAccess(appSlug, requestMember.getId())
 

--- a/src/api/src/main/kotlin/grantly/app/adapter/in/AppController.kt
+++ b/src/api/src/main/kotlin/grantly/app/adapter/in/AppController.kt
@@ -50,7 +50,7 @@ import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @ResponseBody
-@RequestMapping("/v1/apps")
+@RequestMapping("/admin/v1/apps")
 @Tag(name = "앱", description = "멤버가 등록한 앱 관련 API")
 class AppController(
     private val findAppQuery: FindAppQuery,

--- a/src/api/src/main/kotlin/grantly/app/adapter/in/AppController.kt
+++ b/src/api/src/main/kotlin/grantly/app/adapter/in/AppController.kt
@@ -25,7 +25,7 @@ import grantly.common.exceptions.HttpNotFoundException
 import grantly.common.exceptions.HttpUnprocessableException
 import grantly.common.exceptions.PermissionDeniedException
 import grantly.common.utils.HttpUtil
-import grantly.config.AuthenticatedMember
+import grantly.config.AuthenticationEntity
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -82,7 +82,7 @@ class AppController(
     )
     @GetMapping("")
     fun getApps(
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<List<SimpleAppResponse>> {
         val apps = findAppQuery.findAppsByOwnerId(requestMember.getId())
         return ResponseEntity.ok(
@@ -117,7 +117,7 @@ class AppController(
     @PostMapping("")
     fun createApp(
         @RequestBody body: CreateAppRequest,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<CreateAppResponse> {
         val newApp =
             createAppUseCase.createApp(
@@ -202,7 +202,7 @@ class AppController(
     fun uploadImage(
         @PathVariable appSlug: String,
         @RequestPart(required = true) image: MultipartFile,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<Void> {
         try {
             uploadAppImageUseCase.uploadImage(appSlug, requestMember.getId(), image)
@@ -253,7 +253,7 @@ class AppController(
     @DeleteMapping("{appSlug}/image")
     fun deleteImage(
         @PathVariable appSlug: String,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<Void> {
         try {
             deleteAppImageUseCase.deleteImage(appSlug, requestMember.getId())
@@ -311,7 +311,7 @@ class AppController(
     @DeleteMapping("/{slug}")
     fun deleteApp(
         @PathVariable slug: String,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<Void> {
         try {
             deleteAppUseCase.deleteApp(slug, requestMember.getId())
@@ -365,7 +365,7 @@ class AppController(
     @GetMapping("/{slug}")
     fun getApp(
         @PathVariable slug: String,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<AppResponse> {
         val app = appGuard.checkAccess(slug, requestMember.getId())
 
@@ -430,7 +430,7 @@ class AppController(
     fun updateApp(
         @PathVariable slug: String,
         @RequestBody body: UpdateAppRequest,
-        @AuthenticationPrincipal requestMember: AuthenticatedMember,
+        @AuthenticationPrincipal requestMember: AuthenticationEntity,
     ): ResponseEntity<AppResponse> {
         val app =
             try {

--- a/src/api/src/main/kotlin/grantly/config/AuthenticationEntity.kt
+++ b/src/api/src/main/kotlin/grantly/config/AuthenticationEntity.kt
@@ -1,14 +1,20 @@
 package grantly.config
 
+import grantly.session.domain.SubjectType
 import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
-class AuthenticatedMember(
+class AuthenticationEntity(
     private val id: Long,
     private val name: String,
     private val email: String,
+    private val role: SubjectType,
 ) : UserDetails {
-    override fun getAuthorities() = emptyList<GrantedAuthority>()
+    override fun getAuthorities() =
+        listOf<GrantedAuthority>(
+            SimpleGrantedAuthority("ROLE_${role.name}"),
+        )
 
     override fun getPassword() = null
 

--- a/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
+++ b/src/api/src/main/kotlin/grantly/config/filter/SessionValidationFilter.kt
@@ -3,7 +3,7 @@ package grantly.config.filter
 import grantly.common.constants.AuthConstants
 import grantly.common.exceptions.HttpUnauthorizedException
 import grantly.common.utils.HttpUtil
-import grantly.config.AuthenticatedMember
+import grantly.config.AuthenticationEntity
 import grantly.member.application.port.out.MemberRepository
 import grantly.member.domain.MemberDomain
 import grantly.session.application.service.SessionService
@@ -58,15 +58,19 @@ class SessionValidationFilter(
             HttpUtil.writeErrorResponse(response, HttpUnauthorizedException("User not found"))
             return
         }
+        val authenticationEntity =
+            AuthenticationEntity(
+                id = member.id,
+                name = member.name,
+                email = member.email,
+                role = authSession.subjectType!!,
+            )
+
         SecurityContextHolder.getContext().authentication =
             UsernamePasswordAuthenticationToken(
-                AuthenticatedMember(
-                    id = member.id,
-                    name = member.name,
-                    email = member.email,
-                ),
+                authenticationEntity,
                 null,
-                emptyList(), // TODO: 추후 member 와 user 의 Role 구분?
+                authenticationEntity.authorities,
             )
         // 다음 필터로 진행
         filterChain.doFilter(request, response)

--- a/src/api/src/main/kotlin/grantly/member/adapter/in/MemberAuthController.kt
+++ b/src/api/src/main/kotlin/grantly/member/adapter/in/MemberAuthController.kt
@@ -42,8 +42,8 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @ResponseBody
-@RequestMapping("/v1/auth")
-@Tag(name = "인증", description = "인증 관련 API")
+@RequestMapping("/admin/v1/auth")
+@Tag(name = "인증", description = "멤버 인증 관련 API")
 class MemberAuthController(
     private val signUpUseCase: SignUpUseCase,
     private val loginUseCase: LoginUseCase,

--- a/src/api/src/main/kotlin/grantly/member/adapter/in/MemberController.kt
+++ b/src/api/src/main/kotlin/grantly/member/adapter/in/MemberController.kt
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController
 private val log = KotlinLogging.logger {}
 
 @RestController
-@RequestMapping("/v1/members")
+@RequestMapping("/admin/v1/members")
 @Tag(name = "서비스 멤버 API", description = "멤버 관련 API")
 class MemberController(
     private val signUpUseCase: SignUpUseCase,

--- a/src/api/src/main/kotlin/grantly/member/adapter/in/MemberController.kt
+++ b/src/api/src/main/kotlin/grantly/member/adapter/in/MemberController.kt
@@ -1,7 +1,7 @@
 package grantly.member.adapter.`in`
 
 import grantly.common.exceptions.HttpNotFoundException
-import grantly.config.AuthenticatedMember
+import grantly.config.AuthenticationEntity
 import grantly.member.adapter.`in`.dto.SignUpRequest
 import grantly.member.adapter.`in`.dto.UpdateMemberRequest
 import grantly.member.adapter.out.dto.MemberResponse
@@ -35,7 +35,7 @@ class MemberController(
 ) {
     @GetMapping("/me")
     fun getCurrentMember(): ResponseEntity<MemberResponse> {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val member: MemberDomain
         try {
             member = findMemberQuery.findMemberById(requestMember.getId())

--- a/src/api/src/main/kotlin/grantly/member/application/service/MemberService.kt
+++ b/src/api/src/main/kotlin/grantly/member/application/service/MemberService.kt
@@ -92,9 +92,9 @@ class MemberService(
         // 익명 세션으로 요청이 들어온 경우, 현재 멤버와 연결된 세션이 있는지 확인
         if (authSession.isAnonymous()) {
             try {
-                val existingmemberSession = sessionService.findSessionByMemberId(member.id)
+                val existingMemberSession = sessionService.findSessionByMemberId(member.id)
                 // 이미 로그인된 세션이 있는 경우 제거함
-                sessionService.delete(existingmemberSession.id)
+                sessionService.delete(existingMemberSession.id)
             } catch (e: EntityNotFoundException) {
                 // do nothing
             }

--- a/src/api/src/main/kotlin/grantly/session/domain/AuthSessionDomain.kt
+++ b/src/api/src/main/kotlin/grantly/session/domain/AuthSessionDomain.kt
@@ -30,8 +30,9 @@ data class AuthSessionDomain(
         this.deviceId = deviceId ?: this.deviceId
     }
 
-    fun connectMember(userId: Long) {
-        this.subjectId = userId
+    fun connectMember(memberId: Long) {
+        this.subjectType = SubjectType.MEMBER
+        this.subjectId = memberId
     }
 
     fun replaceToken(

--- a/src/api/src/main/kotlin/grantly/system/adapter/in/SystemController.kt
+++ b/src/api/src/main/kotlin/grantly/system/adapter/in/SystemController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @ResponseBody
-@RequestMapping("/v1/system")
+@RequestMapping("/admin/v1/system")
 @Tag(name = "시스템", description = "시스템 관련 API")
 class SystemController {
     @Operation(

--- a/src/api/src/test/kotlin/grantly/app/adapter/in/AppClientControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/app/adapter/in/AppClientControllerTest.kt
@@ -6,7 +6,7 @@ import grantly.app.application.port.out.AppRepository
 import grantly.app.domain.AppClientDomain
 import grantly.app.domain.AppDomain
 import grantly.common.utils.performWithSession
-import grantly.config.AuthenticatedMember
+import grantly.config.AuthenticationEntity
 import grantly.config.TestSessionTokenHolder
 import grantly.config.WithTestSessionMember
 import grantly.member.application.port.out.MemberRepository
@@ -55,7 +55,7 @@ class AppClientControllerTest(
     @DisplayName("OAuth 클라이언트 생성")
     @WithTestSessionMember
     fun createAppClient() {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         val requestData =
             objectMapper.writeValueAsString(
@@ -82,7 +82,7 @@ class AppClientControllerTest(
     @DisplayName("OAuth 클라이언트 수정")
     @WithTestSessionMember
     fun updateAppClient() {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         val appClient = createTestAppClient(app)
         val requestData =
@@ -111,7 +111,7 @@ class AppClientControllerTest(
     @DisplayName("OAuth 클라이언트 삭제")
     @WithTestSessionMember
     fun deleteAppClient() {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         val appClient = createTestAppClient(app)
         mockMvc
@@ -126,7 +126,7 @@ class AppClientControllerTest(
     @DisplayName("OAuth 클라이언트 단일 조회")
     @WithTestSessionMember
     fun getAppClient() {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         val appClient = createTestAppClient(app)
         mockMvc
@@ -144,7 +144,7 @@ class AppClientControllerTest(
     @DisplayName("OAuth 클라이언트 목록 조회")
     @WithTestSessionMember
     fun getAppClients() {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         createTestAppClient(app)
         createTestAppClient(app)
@@ -288,7 +288,7 @@ class AppClientControllerTest(
     @DisplayName("존재하지 않는 OAuth 클라이언트 수정 시 404 에러")
     @WithTestSessionMember
     fun `should return 404 when updating non-existent app client`() {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         val nonExistentClientId = "non-existent-client-id"
 
@@ -315,7 +315,7 @@ class AppClientControllerTest(
     @DisplayName("존재하지 않는 OAuth 클라이언트 삭제 시 404 에러")
     @WithTestSessionMember
     fun `should return 404 when deleting non-existent app client`() {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         val nonExistentClientId = "non-existent-client-id"
 
@@ -330,7 +330,7 @@ class AppClientControllerTest(
     @DisplayName("존재하지 않는 OAuth 클라이언트 조회 시 404 에러")
     @WithTestSessionMember
     fun `should return 404 when getting non-existent app client`() {
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         val nonExistentClientId = "non-existent-client-id"
 

--- a/src/api/src/test/kotlin/grantly/app/adapter/in/AppClientControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/app/adapter/in/AppClientControllerTest.kt
@@ -68,7 +68,7 @@ class AppClientControllerTest(
             )
         mockMvc
             .performWithSession(
-                post("/v1/apps/${app.slug}/clients")
+                post("/admin/v1/apps/${app.slug}/clients")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestData),
                 TestSessionTokenHolder.get(),
@@ -96,7 +96,7 @@ class AppClientControllerTest(
             )
         mockMvc
             .performWithSession(
-                put("/v1/apps/${app.slug}/clients/${appClient.clientId}")
+                put("/admin/v1/apps/${app.slug}/clients/${appClient.clientId}")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestData),
                 TestSessionTokenHolder.get(),
@@ -116,7 +116,7 @@ class AppClientControllerTest(
         val appClient = createTestAppClient(app)
         mockMvc
             .performWithSession(
-                delete("/v1/apps/${app.slug}/clients/${appClient.clientId}"),
+                delete("/admin/v1/apps/${app.slug}/clients/${appClient.clientId}"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isNoContent)
         // 실제 삭제 검증은 별도 repository에서 확인 필요
@@ -131,7 +131,7 @@ class AppClientControllerTest(
         val appClient = createTestAppClient(app)
         mockMvc
             .performWithSession(
-                get("/v1/apps/${app.slug}/clients/${appClient.clientId}"),
+                get("/admin/v1/apps/${app.slug}/clients/${appClient.clientId}"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.clientId").value(appClient.clientId))
@@ -151,7 +151,7 @@ class AppClientControllerTest(
         createTestAppClient(app)
         mockMvc
             .performWithSession(
-                get("/v1/apps/${app.slug}/clients"),
+                get("/admin/v1/apps/${app.slug}/clients"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.length()").value(3))
@@ -183,7 +183,7 @@ class AppClientControllerTest(
             )
         mockMvc
             .performWithSession(
-                post("/v1/apps/${app.slug}/clients")
+                post("/admin/v1/apps/${app.slug}/clients")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestData),
                 TestSessionTokenHolder.get(),
@@ -215,7 +215,7 @@ class AppClientControllerTest(
             )
         mockMvc
             .performWithSession(
-                put("/v1/apps/${app.slug}/clients/${appClient.clientId}")
+                put("/admin/v1/apps/${app.slug}/clients/${appClient.clientId}")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestData),
                 TestSessionTokenHolder.get(),
@@ -238,7 +238,7 @@ class AppClientControllerTest(
         val appClient = createTestAppClient(app)
         mockMvc
             .performWithSession(
-                delete("/v1/apps/${app.slug}/clients/${appClient.clientId}"),
+                delete("/admin/v1/apps/${app.slug}/clients/${appClient.clientId}"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isForbidden)
     }
@@ -259,7 +259,7 @@ class AppClientControllerTest(
         val appClient = createTestAppClient(app)
         mockMvc
             .performWithSession(
-                get("/v1/apps/${app.slug}/clients/${appClient.clientId}"),
+                get("/admin/v1/apps/${app.slug}/clients/${appClient.clientId}"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isForbidden)
     }
@@ -279,7 +279,7 @@ class AppClientControllerTest(
         val app = createTestApp(true, ownerMember.id)
         mockMvc
             .performWithSession(
-                get("/v1/apps/${app.slug}/clients"),
+                get("/admin/v1/apps/${app.slug}/clients"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isForbidden)
     }
@@ -304,7 +304,7 @@ class AppClientControllerTest(
 
         mockMvc
             .performWithSession(
-                put("/v1/apps/${app.slug}/clients/$nonExistentClientId")
+                put("/admin/v1/apps/${app.slug}/clients/$nonExistentClientId")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestData),
                 TestSessionTokenHolder.get(),
@@ -321,7 +321,7 @@ class AppClientControllerTest(
 
         mockMvc
             .performWithSession(
-                delete("/v1/apps/${app.slug}/clients/$nonExistentClientId"),
+                delete("/admin/v1/apps/${app.slug}/clients/$nonExistentClientId"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isNotFound)
     }
@@ -336,7 +336,7 @@ class AppClientControllerTest(
 
         mockMvc
             .performWithSession(
-                get("/v1/apps/${app.slug}/clients/$nonExistentClientId"),
+                get("/admin/v1/apps/${app.slug}/clients/$nonExistentClientId"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isNotFound)
     }
@@ -358,7 +358,7 @@ class AppClientControllerTest(
 
         mockMvc
             .performWithSession(
-                post("/v1/apps/$nonExistentAppSlug/clients")
+                post("/admin/v1/apps/$nonExistentAppSlug/clients")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestData),
                 TestSessionTokenHolder.get(),

--- a/src/api/src/test/kotlin/grantly/app/adapter/in/AppControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/app/adapter/in/AppControllerTest.kt
@@ -69,7 +69,7 @@ class AppControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                get("/v1/apps"),
+                get("/admin/v1/apps"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.length()").value(2))
@@ -91,7 +91,7 @@ class AppControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                post("/v1/apps")
+                post("/admin/v1/apps")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestData),
                 TestSessionTokenHolder.get(),
@@ -117,7 +117,7 @@ class AppControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                delete("/v1/apps/${app.slug}"),
+                delete("/admin/v1/apps/${app.slug}"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isNoContent)
             .andExpect {
@@ -142,7 +142,7 @@ class AppControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                delete("/v1/apps/${app.slug}"),
+                delete("/admin/v1/apps/${app.slug}"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isForbidden)
     }
@@ -157,7 +157,7 @@ class AppControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                delete("/v1/apps/${app.slug}"),
+                delete("/admin/v1/apps/${app.slug}"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isUnprocessableEntity)
     }
@@ -172,7 +172,7 @@ class AppControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                put("/v1/apps/${app.slug}")
+                put("/admin/v1/apps/${app.slug}")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         objectMapper.writeValueAsString(
@@ -209,7 +209,7 @@ class AppControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                multipart("/v1/apps/${app.slug}/image")
+                multipart("/admin/v1/apps/${app.slug}/image")
                     .file(mockFile),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isNoContent)
@@ -239,7 +239,7 @@ class AppControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                delete("/v1/apps/${app.slug}/image"),
+                delete("/admin/v1/apps/${app.slug}/image"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isNoContent)
             .andExpect {

--- a/src/api/src/test/kotlin/grantly/app/adapter/in/AppControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/app/adapter/in/AppControllerTest.kt
@@ -6,7 +6,7 @@ import grantly.app.domain.AppDomain
 import grantly.common.core.store.FileSystemStorage
 import grantly.common.core.store.exceptions.NoSuchResourceException
 import grantly.common.utils.performWithSession
-import grantly.config.AuthenticatedMember
+import grantly.config.AuthenticationEntity
 import grantly.config.TestSessionTokenHolder
 import grantly.config.WithTestSessionMember
 import grantly.member.application.port.out.MemberRepository
@@ -61,7 +61,7 @@ class AppControllerTest(
     @DisplayName("활성화된 애플리케이션만 목록에 포함하여 조회")
     fun `should exclude deactivated apps on list action`() {
         // given
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         createTestApp(true, requestMember.getId())
         createTestApp(false, requestMember.getId())
         val latestApp = createTestApp(true, requestMember.getId())
@@ -80,7 +80,7 @@ class AppControllerTest(
     @DisplayName("앱 생성")
     fun createApp() {
         // given
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val requestData =
             objectMapper.writeValueAsString(
                 mapOf(
@@ -110,7 +110,7 @@ class AppControllerTest(
     @DisplayName("앱 삭제")
     fun deleteApp() {
         // given
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         createTestApp(true, requestMember.getId())
 
@@ -151,7 +151,7 @@ class AppControllerTest(
     @DisplayName("활성화 상태의 앱이 1개뿐일 때 삭제 불가")
     fun `cannot delete the only active app`() {
         // given
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
 
         // when & then
@@ -166,7 +166,7 @@ class AppControllerTest(
     @DisplayName("앱 메타 데이터 수정")
     fun updateApp() {
         // given
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
 
         // when & then
@@ -195,7 +195,7 @@ class AppControllerTest(
     @DisplayName("이미지 업로드 시 이미지 경로가 올바르게 저장된다.")
     fun uploadApplicationImage() {
         // given
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
 
         val mockFile =
@@ -223,7 +223,7 @@ class AppControllerTest(
     @DisplayName("이미지 초기화 시 이미지 경로가 null 로 저장되고 파일이 제거된다.")
     fun deleteApplicationImage() {
         // given
-        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticatedMember
+        val requestMember = SecurityContextHolder.getContext().authentication.principal as AuthenticationEntity
         val app = createTestApp(true, requestMember.getId())
         // 이미지 저장
         runBlocking {

--- a/src/api/src/test/kotlin/grantly/config/WithSessionSecurityContextFactory.kt
+++ b/src/api/src/test/kotlin/grantly/config/WithSessionSecurityContextFactory.kt
@@ -56,7 +56,7 @@ class WithSessionSecurityContextFactory(
         // context 에 설정
         context.authentication =
             UsernamePasswordAuthenticationToken(
-                AuthenticatedMember(
+                AuthenticationEntity(
                     id = member.id,
                     name = member.name,
                     email = member.email,

--- a/src/api/src/test/kotlin/grantly/config/WithTestSessionMember.kt
+++ b/src/api/src/test/kotlin/grantly/config/WithTestSessionMember.kt
@@ -4,7 +4,7 @@ import org.springframework.security.test.context.support.WithSecurityContext
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION) // 클래스와 함수에 적용
 @Retention(AnnotationRetention.RUNTIME) // 런타임까지 유지
-@WithSecurityContext(factory = WithSessionSecurityContextFactory::class) // 커스텀 SecurityContextFactory 설정
+@WithSecurityContext(factory = WithMemberSessionSecurityContextFactory::class) // 커스텀 SecurityContextFactory 설정
 annotation class WithTestSessionMember(
     val email: String = "test@email.com", // 기본 이메일
     val name: String = "testUser", // 기본 사용자 이름

--- a/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/member/adapter/in/AuthControllerTest.kt
@@ -106,7 +106,7 @@ class AuthControllerTest(
         val jsonBody = objectMapper.writeValueAsString(SignUpRequest(existingMember.email, "test2", "test123!"))
         mockMvc
             .perform(
-                post("/v1/auth/signup")
+                post("/admin/v1/auth/signup")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isConflict)
@@ -123,7 +123,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/signup")
+                post("/admin/v1/auth/signup")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isCreated)
@@ -149,7 +149,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/signup")
+                post("/admin/v1/auth/signup")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isUnprocessableEntity)
@@ -165,7 +165,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/login")
+                post("/admin/v1/auth/login")
                     .cookie(Cookie(AuthConstants.SESSION_COOKIE_NAME, session.token))
                     .cookie(Cookie(AuthConstants.DEVICE_ID_COOKIE_NAME, session.deviceId))
                     .contentType(MediaType.APPLICATION_JSON)
@@ -190,7 +190,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/login")
+                post("/admin/v1/auth/login")
                     .contentType(MediaType.APPLICATION_JSON)
                     .cookie(
                         Cookie(AuthConstants.DEVICE_ID_COOKIE_NAME, anonSession.deviceId),
@@ -215,7 +215,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/login")
+                post("/admin/v1/auth/login")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isUnauthorized)
@@ -230,7 +230,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/login")
+                post("/admin/v1/auth/login")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isUnauthorized)
@@ -242,7 +242,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                get("/v1/auth/csrf-token"),
+                get("/admin/v1/auth/csrf-token"),
             ).andExpect(status().isNoContent)
             .andExpect(cookie().exists(AuthConstants.CSRF_COOKIE_NAME))
     }
@@ -256,7 +256,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                get("/v1/auth/csrf-token")
+                get("/admin/v1/auth/csrf-token")
                     .cookie(Cookie(AuthConstants.SESSION_COOKIE_NAME, authSession.token)),
             ).andExpect(status().isNoContent)
             .andExpect(cookie().exists(AuthConstants.CSRF_COOKIE_NAME))
@@ -271,7 +271,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/logout")
+                post("/admin/v1/auth/logout")
                     .cookie(Cookie(AuthConstants.SESSION_COOKIE_NAME, authSession.token)),
             ).andExpect(status().isNoContent)
             .andExpect { result ->
@@ -295,7 +295,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/request-password-reset")
+                post("/admin/v1/auth/request-password-reset")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isNoContent)
@@ -315,7 +315,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/request-password-reset")
+                post("/admin/v1/auth/request-password-reset")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isNoContent)
@@ -348,7 +348,7 @@ class AuthControllerTest(
         // when & then
         mockMvc
             .perform(
-                post("/v1/auth/reset-password")
+                post("/admin/v1/auth/reset-password")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonBody),
             ).andExpect(status().isNoContent)

--- a/src/api/src/test/kotlin/grantly/member/adapter/in/MemberControllerTest.kt
+++ b/src/api/src/test/kotlin/grantly/member/adapter/in/MemberControllerTest.kt
@@ -37,7 +37,7 @@ class MemberControllerTest(
         // when & then
         mockMvc
             .performWithSession(
-                get("/v1/members/me"),
+                get("/admin/v1/members/me"),
                 TestSessionTokenHolder.get(),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.email").value("test@email.com"))


### PR DESCRIPTION
## 변경내역
- 멤버용 엔드포인트에 /admin prefix 추가
- 로그인한 role 에 따로 AuthenticatedEntity 내 role 세팅
- resolves #120 

## 확인이 필요한 부분
-

## 배포 전 해야 할 일

- [ ]

### DB schema change

- [ ]

## 배포 후 해야 할 일

- [ ]

### DB schema change

- [ ]
