### PR TITLE
oauth_consent 테이블 추가

### DIFF
--- a/src/api/src/main/kotlin/grantly/oauth/adapter/out/OAuthConsentJpaEntity.kt
+++ b/src/api/src/main/kotlin/grantly/oauth/adapter/out/OAuthConsentJpaEntity.kt
@@ -1,0 +1,64 @@
+package grantly.oauth.adapter.out
+
+import grantly.app.adapter.out.AppClientJpaEntity
+import grantly.common.entity.BaseEntity
+import grantly.common.entity.entityEquals
+import grantly.common.entity.entityHashCode
+import grantly.common.entity.entityToString
+import grantly.member.adapter.out.MemberJpaEntity
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.OffsetDateTime
+
+@Entity
+@Table(name = "oauth_consent")
+class OAuthConsentJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id", updatable = false, insertable = false)
+    val user: MemberJpaEntity? = null, // FIXME: member -> user 로 이름 바뀔 예정
+    @Column(name = "user_id")
+    val userId: Long,
+    @ManyToOne
+    @JoinColumn(
+        name = "app_client_id",
+        nullable = false,
+        referencedColumnName = "id",
+        updatable = false,
+        insertable = false,
+    )
+    val appClient: AppClientJpaEntity? = null,
+    @Column(name = "app_client_id")
+    val appClientId: Long,
+    @ElementCollection
+    @CollectionTable(name = "oauth_consent_granted_scope", joinColumns = [JoinColumn(name = "consent_id")])
+    @Column(name = "granted_scope")
+    var grantedScopes: MutableList<String> = mutableListOf(),
+    @Column(nullable = false)
+    var consentedAt: OffsetDateTime,
+) : BaseEntity() {
+    override fun equals(other: Any?) = entityEquals(other, OAuthConsentJpaEntity::id)
+
+    override fun hashCode() = entityHashCode(OAuthConsentJpaEntity::id)
+
+    override fun toString() = entityToString(*toStringProperties)
+
+    companion object {
+        val toStringProperties =
+            arrayOf(
+                OAuthConsentJpaEntity::id,
+                OAuthConsentJpaEntity::userId,
+                OAuthConsentJpaEntity::appClientId,
+                OAuthConsentJpaEntity::consentedAt,
+            )
+    }
+}

--- a/src/api/src/main/kotlin/grantly/oauth/adapter/out/OAuthConsentJpaRepository.kt
+++ b/src/api/src/main/kotlin/grantly/oauth/adapter/out/OAuthConsentJpaRepository.kt
@@ -1,0 +1,11 @@
+package grantly.oauth.adapter.out
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface OAuthConsentJpaRepository : JpaRepository<OAuthConsentJpaEntity, Long> {
+    fun findByAppClientIdAndUserId(
+        appClientId: Long,
+        userId: Long,
+    ): Optional<OAuthConsentJpaEntity>
+}

--- a/src/api/src/main/kotlin/grantly/oauth/adapter/out/OAuthConsentMapper.kt
+++ b/src/api/src/main/kotlin/grantly/oauth/adapter/out/OAuthConsentMapper.kt
@@ -1,0 +1,28 @@
+package grantly.oauth.adapter.out
+
+import grantly.common.entity.IsMapper
+import grantly.oauth.domain.OAuthConsentDomain
+import org.springframework.stereotype.Component
+
+@Component
+class OAuthConsentMapper : IsMapper<OAuthConsentJpaEntity, OAuthConsentDomain> {
+    override fun toDomain(entity: OAuthConsentJpaEntity): OAuthConsentDomain =
+        OAuthConsentDomain(
+            id = entity.id ?: 0L,
+            appClientId = entity.appClientId,
+            userId = entity.userId,
+            grantedScopes = entity.grantedScopes.toMutableList(),
+            consentedAt = entity.consentedAt,
+            createdAt = entity.createdAt,
+            modifiedAt = entity.modifiedAt,
+        )
+
+    override fun toEntity(domain: OAuthConsentDomain): OAuthConsentJpaEntity =
+        OAuthConsentJpaEntity(
+            id = if (domain.id == 0L) null else domain.id,
+            userId = domain.userId,
+            appClientId = domain.appClientId,
+            grantedScopes = domain.grantedScopes.toMutableList(),
+            consentedAt = domain.consentedAt,
+        )
+}

--- a/src/api/src/main/kotlin/grantly/oauth/adapter/out/OAuthConsentPersistenceAdapter.kt
+++ b/src/api/src/main/kotlin/grantly/oauth/adapter/out/OAuthConsentPersistenceAdapter.kt
@@ -1,0 +1,17 @@
+package grantly.oauth.adapter.out
+
+import grantly.common.annotations.PersistenceAdapter
+import grantly.oauth.application.port.out.OAuthConsentRepository
+import grantly.oauth.domain.OAuthConsentDomain
+
+@PersistenceAdapter
+class OAuthConsentPersistenceAdapter(
+    private val oAuthConsentJpaRepository: OAuthConsentJpaRepository,
+    private val mapper: OAuthConsentMapper,
+) : OAuthConsentRepository {
+    override fun createConsent(domain: OAuthConsentDomain): OAuthConsentDomain {
+        val entity = mapper.toEntity(domain)
+        val savedEntity = oAuthConsentJpaRepository.save(entity)
+        return mapper.toDomain(savedEntity)
+    }
+}

--- a/src/api/src/main/kotlin/grantly/oauth/application/port/out/OAuthConsentRepository.kt
+++ b/src/api/src/main/kotlin/grantly/oauth/application/port/out/OAuthConsentRepository.kt
@@ -1,0 +1,7 @@
+package grantly.oauth.application.port.out
+
+import grantly.oauth.domain.OAuthConsentDomain
+
+interface OAuthConsentRepository {
+    fun createConsent(domain: OAuthConsentDomain): OAuthConsentDomain
+}

--- a/src/api/src/main/kotlin/grantly/oauth/domain/OAuthConsentDomain.kt
+++ b/src/api/src/main/kotlin/grantly/oauth/domain/OAuthConsentDomain.kt
@@ -1,0 +1,15 @@
+package grantly.oauth.domain
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.OffsetDateTime
+
+@Schema(description = "OAuth 권한 부여 동의 도메인 모델")
+data class OAuthConsentDomain(
+    val id: Long = 0L,
+    val appClientId: Long,
+    val userId: Long,
+    val grantedScopes: MutableList<String> = mutableListOf(),
+    val consentedAt: OffsetDateTime,
+    val createdAt: OffsetDateTime = OffsetDateTime.now(),
+    var modifiedAt: OffsetDateTime? = null,
+)

--- a/src/api/src/main/resources/migrations/V12__add_oauth_consent.sql
+++ b/src/api/src/main/resources/migrations/V12__add_oauth_consent.sql
@@ -1,0 +1,25 @@
+CREATE TABLE oauth_consent
+(
+    id            BIGINT AUTO_INCREMENT NOT NULL,
+    created_at    datetime              NOT NULL,
+    modified_at   datetime              NOT NULL,
+    user_id       BIGINT                NULL,
+    app_client_id BIGINT                NULL,
+    consented_at  datetime              NOT NULL,
+    CONSTRAINT pk_oauth_consent PRIMARY KEY (id)
+);
+
+CREATE TABLE oauth_consent_granted_scope
+(
+    consent_id    BIGINT       NOT NULL,
+    granted_scope VARCHAR(255) NULL
+);
+
+ALTER TABLE oauth_consent
+    ADD CONSTRAINT FK_OAUTH_CONSENT_ON_APPCLIENT FOREIGN KEY (app_client_id) REFERENCES app_client (id);
+
+ALTER TABLE oauth_consent
+    ADD CONSTRAINT FK_OAUTH_CONSENT_ON_USER FOREIGN KEY (user_id) REFERENCES member (id);
+
+ALTER TABLE oauth_consent_granted_scope
+    ADD CONSTRAINT fk_oauth_consent_granted_scope_on_o_auth_consent_jpa_entity FOREIGN KEY (consent_id) REFERENCES oauth_consent (id);


### PR DESCRIPTION
## 변경내역
- /oauth/v1/authorize 호출 시 권한 부여 동의 내역을 기록할 테이블입니다.

## 확인이 필요한 부분
-

## 배포 전 해야 할 일

- [ ]

### DB schema change

- [ ]

## 배포 후 해야 할 일

- [ ] V12
```sql
CREATE TABLE oauth_consent
(
    id            BIGINT AUTO_INCREMENT NOT NULL,
    created_at    datetime              NOT NULL,
    modified_at   datetime              NOT NULL,
    user_id       BIGINT                NULL,
    app_client_id BIGINT                NULL,
    consented_at  datetime              NOT NULL,
    CONSTRAINT pk_oauth_consent PRIMARY KEY (id)
);

CREATE TABLE oauth_consent_granted_scope
(
    consent_id    BIGINT       NOT NULL,
    granted_scope VARCHAR(255) NULL
);

ALTER TABLE oauth_consent
    ADD CONSTRAINT FK_OAUTH_CONSENT_ON_APPCLIENT FOREIGN KEY (app_client_id) REFERENCES app_client (id);

ALTER TABLE oauth_consent
    ADD CONSTRAINT FK_OAUTH_CONSENT_ON_USER FOREIGN KEY (user_id) REFERENCES member (id);

ALTER TABLE oauth_consent_granted_scope
    ADD CONSTRAINT fk_oauth_consent_granted_scope_on_o_auth_consent_jpa_entity FOREIGN KEY (consent_id) REFERENCES oauth_consent (id);
```

### DB schema change

- [ ]
